### PR TITLE
Add token "sub" field to env, as "jitsi_xmpp_domain"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 - Add an API route to generate a token
 - If user is logged in, created token on API route contains their information
 - If user is not logged in, created token contains guest information
+- Sub field in token is a variable referencing jitsi xmpp domain
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -73,15 +73,18 @@ Jitsi magnify helps with authenticating users when they access jitsi rooms. Curr
 
 The domain of jitsi instance that uses magnify should be referenced in `env.d/development/common`. As for jitsi, env variables should be set to enable jwt auth and to redirect to magnify instance. 
 
-These variables are : 
+Variables for jwt are : 
 ````
 ENABLE_AUTH=1
 AUTH_TYPE=jwt
 JWT_APP_ID={JWT_JITSI_APP_ID}
+JWT_APP_SECRET={JWT_JITSI_APP_SECRET}
 TOKEN_AUTH_URL=https://{JWT_JITSI_DOMAIN}/api/token/{room}
 ````
 
-With JWT_JITSI_APP_ID and JWT_JITSI_DOMAIN equal to the values in `env.d/development/common`.
+In prosody env, you should also set variable `XMPP_DOMAIN={JWT_JITSI_XMPP_DOMAIN}`.
+
+The above JWT_JITSI_APP_ID, JWT_JITSI_APP_SECRET, JWT_JITSI_DOMAIN and JWT_JITSI_XMPP_DOMAIN variables are equal to the values in `env.d/development/common`.
 
 ## Contributing
 

--- a/env.d/development/common
+++ b/env.d/development/common
@@ -11,6 +11,7 @@ JWT_GUEST_AVATAR="https://ronaldmottram.co.nz/wp-content/uploads/2019/01/default
 JWT_GUEST_DEFAULT_PASSWORD="default"
 JWT_GUEST_USERNAME="guest"
 JWT_JITSI_DOMAIN="localhost:8443"
+JWT_JITSI_XMPP_DOMAIN="meet.jitsi"
 JWT_JITSI_SECRET_KEY="ThisIsAnExampleKeyForDevPurposeOnly"
 JWT_JITSI_APP_ID="app_id"
 

--- a/src/backend/magnify/core/views.py
+++ b/src/backend/magnify/core/views.py
@@ -18,8 +18,8 @@ def create_payload(user, room):
         "iat": timezone.now(),
         "moderator": True,
         "aud": "jitsi",
-        "iss": settings.JWT_CONFIGURATION.get("jitsi_app_id"),
-        "sub": "meet.jitsi",
+        "iss": settings.JWT_CONFIGURATION["jitsi_app_id"],
+        "sub": settings.JWT_CONFIGURATION["jitsi_xmpp_domain"],
         "room": room,
     }
 
@@ -40,7 +40,7 @@ def generate_token(user, room):
     token_payload = create_payload(user, room)
     token = jwt.encode(
         token_payload,
-        settings.JWT_CONFIGURATION.get("jitsi_secret_key"),
+        settings.JWT_CONFIGURATION["jitsi_secret_key"],
         algorithm="HS256",
     )
 

--- a/src/backend/magnify/settings.py
+++ b/src/backend/magnify/settings.py
@@ -198,7 +198,10 @@ class Base(Configuration):
             environ_name="JWT_JITSI_DOMAIN", environ_prefix=None
         ),
         "jitsi_app_id": values.Value(
-            "", environ_name="JWT_JITSI_APP_ID", environ_prefix=None
+            environ_name="JWT_JITSI_APP_ID", environ_prefix=None
+        ),
+        "jitsi_xmpp_domain": values.Value(
+            environ_name="JWT_JITSI_XMPP_DOMAIN", environ_prefix=None
         ),
         "jitsi_secret_key": values.SecretValue(
             environ_name="JWT_JITSI_SECRET_KEY", environ_prefix=None

--- a/src/backend/magnify/tests/test_redirect.py
+++ b/src/backend/magnify/tests/test_redirect.py
@@ -17,6 +17,7 @@ from magnify.core.factories import UserFactory
         "token_expiration_seconds": 600,
         "jitsi_app_id": "app_id",
         "jitsi_domain": "meet.jit.si",
+        "jitsi_xmpp_domain": "meet.jitsi",
         "guest_username": "guest",
         "guest_avatar": "avatar.jpg",
     }


### PR DESCRIPTION
## Purpose

In token, "sub" field is the xmpp domain of server.
So this should be an env variable as it depends on which jitsi instance we want magnify to deliver tokens to
