### PR TITLE
Create components for user page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Fix storybook not starting up due to storybook packages version
 
 ## [Unrealeased]
+
+### Added
+
+- Add components for the profile pages (identity, avatars, delete account)

--- a/src/frontend/demo/package.json
+++ b/src/frontend/demo/package.json
@@ -17,6 +17,7 @@
     "stream": "npm:stream-browserify",
     "stream-browserify": "3.0.0",
     "styled-components": "5.3.5",
+    "validator": "13.7.0",
     "web-vitals": "2.1.0"
   },
   "devDependencies": {

--- a/src/frontend/magnify/.storybook/theme.js
+++ b/src/frontend/magnify/.storybook/theme.js
@@ -29,4 +29,11 @@ export default {
       radius: '5px',
     },
   },
+  input: {
+    border: false,
+    weight: 'normal',
+  },
+  formField: {
+    border: false,
+  },
 };

--- a/src/frontend/magnify/package.json
+++ b/src/frontend/magnify/package.json
@@ -33,7 +33,7 @@
     "@storybook/testing-library": "0.0.13",
     "@testing-library/jest-dom": "5.16.4",
     "@testing-library/react": "13.3.0",
-    "@testing-library/user-event": "14.2.0",
+    "@testing-library/user-event": "14.2.1",
     "@types/jest": "28.1.1",
     "@types/react": "18.0.12",
     "@types/styled-components": "5.1.25",

--- a/src/frontend/magnify/package.json
+++ b/src/frontend/magnify/package.json
@@ -37,6 +37,7 @@
     "@types/jest": "28.1.1",
     "@types/react": "18.0.12",
     "@types/styled-components": "5.1.25",
+    "@types/validator": "13.7.3",
     "@typescript-eslint/eslint-plugin": "5.28.0",
     "@typescript-eslint/parser": "5.28.0",
     "babel-plugin-react-intl": "8.2.25",
@@ -76,7 +77,8 @@
     "react-intl": "6.0.4",
     "react-query": "3.39.1",
     "react-router-dom": "6.3.0",
-    "styled-components": "5.3.5"
+    "styled-components": "5.3.5",
+    "validator": "13.7.0"
   },
   "dependencies": {}
 }

--- a/src/frontend/magnify/src/components/design-system/TextField/TextField.stories.tsx
+++ b/src/frontend/magnify/src/components/design-system/TextField/TextField.stories.tsx
@@ -31,3 +31,15 @@ WithErrors.args = {
   ...baseArgs,
   errors: ['This is an error'],
 };
+
+export const Required = Template.bind({});
+Required.args = {
+  ...baseArgs,
+  required: true,
+};
+
+export const Password = Template.bind({});
+Password.args = {
+  ...baseArgs,
+  type: 'password',
+};

--- a/src/frontend/magnify/src/components/design-system/TextField/TextField.stories.tsx
+++ b/src/frontend/magnify/src/components/design-system/TextField/TextField.stories.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import TextField from './TextField';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'DesignSystem/TextField',
+  component: TextField,
+} as ComponentMeta<typeof TextField>;
+
+const Template: ComponentStory<typeof TextField> = (args) => <TextField {...args} />;
+
+const baseArgs = {
+  label: 'My input',
+  name: 'my-input',
+  onChange: console.log,
+  value: 'xxx',
+};
+
+// create the template and 2 stories for variants blue and red
+export const Simple = Template.bind({});
+Simple.args = { ...baseArgs };
+
+export const WithMargin = Template.bind({});
+WithMargin.args = {
+  ...baseArgs,
+  margin: 'large',
+};
+
+export const WithErrors = Template.bind({});
+WithErrors.args = {
+  ...baseArgs,
+  errors: ['This is an error'],
+};

--- a/src/frontend/magnify/src/components/design-system/TextField/TextField.test.tsx
+++ b/src/frontend/magnify/src/components/design-system/TextField/TextField.test.tsx
@@ -20,7 +20,7 @@ describe('TextField', () => {
 
     render(<TestElement />);
 
-    const input = screen.getByLabelText('My input') as HTMLInputElement;
+    const input = screen.getByRole<HTMLInputElement>('textbox', { name: 'My input' });
 
     await user.type(input, ' World');
     expect(input.value).toBe('Hello World');
@@ -35,7 +35,7 @@ describe('TextField', () => {
 
   it('should add a star for required fields', () => {
     render(<TextField label="My input" name="my-input" onChange={() => {}} value="" required />);
-    screen.getByLabelText('My input*');
+    screen.getByRole('textbox', { name: 'My input *' });
   });
 
   it('should render the error messages by default', () => {
@@ -79,7 +79,7 @@ describe('TextField', () => {
       />,
     );
 
-    const input = screen.getByLabelText('My input') as HTMLInputElement;
+    const input = screen.getByLabelText<HTMLInputElement>('My input') as HTMLInputElement;
     const button = screen.getByTitle('Show');
 
     expect(input.type).toBe('password');

--- a/src/frontend/magnify/src/components/design-system/TextField/TextField.test.tsx
+++ b/src/frontend/magnify/src/components/design-system/TextField/TextField.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import TextField from './TextField';
+
+describe('TextField', () => {
+  it('should follow the user typing', async () => {
+    const user = userEvent.setup();
+    const TestElement = () => {
+      const [value, setValue] = React.useState('Hello');
+      return (
+        <TextField
+          label="My input"
+          name="my-input"
+          onChange={(e) => setValue(e.target.value)}
+          value={value}
+        />
+      );
+    };
+
+    render(<TestElement />);
+
+    const input = screen.getByLabelText('My input') as HTMLInputElement;
+
+    await user.type(input, ' World');
+    expect(input.value).toBe('Hello World');
+  });
+
+  it('should apply the margin to the external box', () => {
+    const { baseElement } = render(
+      <TextField label="My input" name="my-input" onChange={() => {}} value="" margin="large" />,
+    );
+    expect(baseElement).toHaveStyle('margin: 8px');
+  });
+
+  it('should render the error messages', () => {
+    render(
+      <TextField
+        label="My input"
+        name="my-input"
+        onChange={() => {}}
+        value=""
+        errors={['This is an error', 'This is another error']}
+      />,
+    );
+
+    screen.getByText('This is an error, This is another error');
+  });
+});

--- a/src/frontend/magnify/src/components/design-system/TextField/TextField.test.tsx
+++ b/src/frontend/magnify/src/components/design-system/TextField/TextField.test.tsx
@@ -33,7 +33,12 @@ describe('TextField', () => {
     expect(baseElement).toHaveStyle('margin: 8px');
   });
 
-  it('should render the error messages', () => {
+  it('should add a star for required fields', () => {
+    render(<TextField label="My input" name="my-input" onChange={() => {}} value="" required />);
+    screen.getByLabelText('My input*');
+  });
+
+  it('should render the error messages by default', () => {
     render(
       <TextField
         label="My input"
@@ -45,5 +50,42 @@ describe('TextField', () => {
     );
 
     screen.getByText('This is an error, This is another error');
+  });
+
+  it('should not render the error messages if displayErrors is false', () => {
+    render(
+      <TextField
+        label="My input"
+        name="my-input"
+        onChange={() => {}}
+        value=""
+        errors={['This is an error', 'This is another error']}
+        displayErrors={false}
+      />,
+    );
+
+    expect(screen.queryByText('This is an error, This is another error')).not.toBeInTheDocument();
+  });
+
+  it('should add a button to reveal password if type is password', async () => {
+    const user = userEvent.setup();
+    render(
+      <TextField
+        label="My input"
+        name="my-input"
+        onChange={() => {}}
+        value="pass"
+        type="password"
+      />,
+    );
+
+    const input = screen.getByLabelText('My input') as HTMLInputElement;
+    const button = screen.getByTitle('Show');
+
+    expect(input.type).toBe('password');
+    await user.click(button);
+    expect(input.type).toBe('text');
+    await user.click(button);
+    expect(input.type).toBe('password');
   });
 });

--- a/src/frontend/magnify/src/components/design-system/TextField/TextField.tsx
+++ b/src/frontend/magnify/src/components/design-system/TextField/TextField.tsx
@@ -1,24 +1,70 @@
-import { Box, Text, TextInput } from 'grommet';
+import { Box, Button, Text, TextInput } from 'grommet';
 import { MarginType } from 'grommet/utils';
-import React from 'react';
+import React, { useState } from 'react';
+import { View, Hide } from 'grommet-icons';
 
 export interface TextFieldProps {
+  /**
+   * Should we display error messages if any?
+   * It can be a good idea to not to display error messages at the very beginning
+   * @default true
+   */
+  displayErrors?: boolean;
+  /**
+   * The error messages to display
+   * @default []
+   */
   errors?: string[];
+  /**
+   * The label for the text field
+   * @required
+   */
   label: string;
+  /**
+   * Additional margin to apply to the text field
+   * @default: 'none'
+   */
   margin?: MarginType;
+  /**
+   * The name of the text field
+   * @required
+   */
   name: string;
+  /**
+   * The callback to call when the value of the text field changes
+   * @required
+   */
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  /**
+   * Is the text field required? (should display an indicator if yes)
+   * @default false
+   */
+  required?: boolean;
+  /**
+   * The type of the text field (text, password, ...)
+   * Currently only text and password are supported
+   * @default 'text'
+   */
+  type?: 'text' | 'password';
+  /**
+   * The value of the text field
+   */
   value: string;
 }
 
 export default function TextField({
+  displayErrors = true,
   errors = [],
   label,
-  margin,
+  margin = 'none',
   name,
   onChange,
+  required = false,
+  type = 'text',
   value,
 }: TextFieldProps) {
+  const [revealPassword, setRevealPassword] = useState(false);
+
   return (
     <Box
       border={{ side: 'all', color: 'brand' }}
@@ -31,16 +77,32 @@ export default function TextField({
           <Text size="xsmall" weight="bold" color="brand">
             {label}
           </Text>
+          {required && (
+            <Text size="xsmall" color="status-error" margin={{ left: 'xxsmall' }}>
+              *
+            </Text>
+          )}
         </label>
       </Box>
-      <TextInput
-        name={name}
-        id={name}
-        value={value}
-        onChange={onChange}
-        style={{ border: 'none' }}
-      />
-      {errors.length > 0 && (
+      <Box direction="row">
+        <TextInput
+          name={name}
+          id={name}
+          value={value}
+          onChange={onChange}
+          style={{ border: 'none' }}
+          type={type === 'password' ? (revealPassword ? 'text' : 'password') : type}
+        />
+        {type === 'password' && (
+          <Button
+            icon={revealPassword ? <View /> : <Hide />}
+            onClick={() => setRevealPassword(!revealPassword)}
+            style={{ padding: '7px' }}
+            title={revealPassword ? 'Hide' : 'Show'}
+          />
+        )}
+      </Box>
+      {displayErrors && errors.length > 0 && (
         <Box margin={{ left: '11px' }}>
           <Text size="xsmall" color="status-error">
             {errors.join(', ')}

--- a/src/frontend/magnify/src/components/design-system/TextField/TextField.tsx
+++ b/src/frontend/magnify/src/components/design-system/TextField/TextField.tsx
@@ -1,0 +1,52 @@
+import { Box, Text, TextInput } from 'grommet';
+import { MarginType } from 'grommet/utils';
+import React from 'react';
+
+export interface TextFieldProps {
+  errors?: string[];
+  label: string;
+  margin?: MarginType;
+  name: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  value: string;
+}
+
+export default function TextField({
+  errors = [],
+  label,
+  margin,
+  name,
+  onChange,
+  value,
+}: TextFieldProps) {
+  return (
+    <Box
+      border={{ side: 'all', color: 'brand' }}
+      round="8px"
+      pad={{ vertical: 'xsmall', horizontal: 'small' }}
+      margin={margin}
+    >
+      <Box margin={{ left: '11px' }}>
+        <label htmlFor={name}>
+          <Text size="xsmall" weight="bold" color="brand">
+            {label}
+          </Text>
+        </label>
+      </Box>
+      <TextInput
+        name={name}
+        id={name}
+        value={value}
+        onChange={onChange}
+        style={{ border: 'none' }}
+      />
+      {errors.length > 0 && (
+        <Box margin={{ left: '11px' }}>
+          <Text size="xsmall" color="status-error">
+            {errors.join(', ')}
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/frontend/magnify/src/components/design-system/TextField/index.ts
+++ b/src/frontend/magnify/src/components/design-system/TextField/index.ts
@@ -1,0 +1,1 @@
+export { default, TextFieldProps } from './TextField';

--- a/src/frontend/magnify/src/components/design-system/index.ts
+++ b/src/frontend/magnify/src/components/design-system/index.ts
@@ -1,2 +1,3 @@
 export { default as RowsList, HeaderProps, RowPropsExtended, RowsListProps } from './RowsList';
 export { default as LoadingButton } from './LoadingButton';
+export { default as TextField, TextFieldProps } from './TextField';

--- a/src/frontend/magnify/src/components/index.ts
+++ b/src/frontend/magnify/src/components/index.ts
@@ -1,4 +1,5 @@
 export { default as TestButton, TestButtonVariant } from './TestButton';
 
-export * from './groups';
 export * from './design-system';
+export * from './groups';
+export * from './profile';

--- a/src/frontend/magnify/src/components/index.ts
+++ b/src/frontend/magnify/src/components/index.ts
@@ -3,3 +3,4 @@ export { default as TestButton, TestButtonVariant } from './TestButton';
 export * from './design-system';
 export * from './groups';
 export * from './profile';
+export * from './design-system';

--- a/src/frontend/magnify/src/components/profile/AvatarForm/AvatarForm.stories.tsx
+++ b/src/frontend/magnify/src/components/profile/AvatarForm/AvatarForm.stories.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import AvatarForm from './AvatarForm';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'profile/AvatarForm',
+  component: AvatarForm,
+} as ComponentMeta<typeof AvatarForm>;
+
+const Template: ComponentStory<typeof AvatarForm> = (args) => <AvatarForm {...args} />;
+
+// create the template and 2 stories for variants blue and red
+export const Simple = Template.bind({});
+Simple.args = {
+  src: 'https://i.pravatar.cc/120?img=12',
+};
+
+export const NoImage = Template.bind({});
+NoImage.args = {};

--- a/src/frontend/magnify/src/components/profile/AvatarForm/AvatarForm.test.tsx
+++ b/src/frontend/magnify/src/components/profile/AvatarForm/AvatarForm.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import AvatarForm from './AvatarForm';
+import userEvent from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+
+describe('AvatarForm', () => {
+  it('should render the default avatar, and when a new one is loaded, it should display it as preview', async () => {
+    const user = userEvent.setup();
+    render(
+      <IntlProvider locale="en">
+        <AvatarForm src="test.jpg" />
+      </IntlProvider>,
+    );
+
+    // Verify the default layout
+    const uploadLabel = screen.getByText('Load new avatar');
+    const avatarImage = screen.getByTitle('Your avatar');
+    expect(avatarImage).toHaveStyle('background-image: url(test.jpg)');
+
+    // Import a new file
+    const file = new File(['hello'], 'hello.png', { type: 'image/png' });
+    await user.upload(uploadLabel.parentElement as HTMLElement, file);
+
+    // Verify the new layout: it should be a new save button, a new image, and a new remove button
+    await screen.findByText('Save');
+    await screen.findByLabelText('Remove avatar');
+    expect(avatarImage).toHaveStyle('background-image: url(data:image/png;base64,aGVsbG8=)');
+  });
+});

--- a/src/frontend/magnify/src/components/profile/AvatarForm/AvatarForm.tsx
+++ b/src/frontend/magnify/src/components/profile/AvatarForm/AvatarForm.tsx
@@ -1,0 +1,109 @@
+import { Avatar, Box, Button, Card } from 'grommet';
+import { User } from 'grommet-icons';
+import React from 'react';
+import { Trash } from 'grommet-icons';
+import { defineMessages, useIntl } from 'react-intl';
+
+export interface AvatarFormProps {
+  src?: string;
+}
+
+const messages = defineMessages({
+  loadNewButtonLabel: {
+    defaultMessage: 'Load new avatar',
+    description: 'Call to action on the load new avatar button',
+    id: 'components.profile.AvatarForm.loadNewButtonLabel',
+  },
+  removeButtonLabel: {
+    defaultMessage: 'Remove avatar',
+    description: 'Call to action on the remove avatar button',
+    id: 'components.profile.AvatarForm.removeButtonLabel',
+  },
+  saveNewAvatarButtonLabel: {
+    defaultMessage: 'Save',
+    description: 'Call to action on the save new avatar button',
+    id: 'components.profile.AvatarForm.saveNewAvatarButtonLabel',
+  },
+});
+
+export default function AvatarForm({ src: defaultSrc = '' }: AvatarFormProps) {
+  const intl = useIntl();
+  const [src, setSrc] = React.useState<string>(defaultSrc);
+  const [changed, setChanged] = React.useState<boolean>(false);
+
+  const handleSubmit = () => {
+    setChanged(false);
+  };
+
+  const handleRemove = () => {
+    setChanged(false);
+    setSrc(defaultSrc);
+  };
+
+  const avatarProps = src !== '' ? { src } : { children: <User size="large" /> };
+
+  return (
+    <Box direction="column" width="190px">
+      <Card width="190px" height="190px" background="light-2">
+        <Avatar
+          size="120px"
+          margin="auto"
+          title="Your avatar"
+          background="light-4"
+          {...avatarProps}
+        />
+      </Card>
+
+      {!changed && (
+        <label htmlFor="avatar-file-input">
+          <Button
+            label={intl.formatMessage(messages.loadNewButtonLabel)}
+            margin={{ top: 'small' }}
+            primary
+            as="div"
+            style={{ width: '100%' }}
+          />
+        </label>
+      )}
+
+      {changed && (
+        <Box direction="row" margin={{ top: 'small' }}>
+          <Button
+            label={intl.formatMessage(messages.saveNewAvatarButtonLabel)}
+            primary
+            onClick={handleSubmit}
+            style={{ flexGrow: 1 }}
+            margin={{ right: 'small', vertical: 'auto' }}
+          />
+          <Button
+            icon={<Trash />}
+            hoverIndicator
+            onClick={handleRemove}
+            tip={intl.formatMessage(messages.removeButtonLabel)}
+          />
+        </Box>
+      )}
+
+      <input
+        name="avatar-file-input"
+        id="avatar-file-input"
+        accept="image/png, image/jpeg"
+        type="file"
+        style={{ display: 'none' }}
+        onChange={(event) => {
+          const file = event.target.files && event.target.files[0];
+          if (file) {
+            const reader = new FileReader();
+            reader.onload = (e) => {
+              if (e.target) {
+                setSrc(e.target.result as string);
+                setChanged(true);
+              }
+            };
+            reader.readAsDataURL(file);
+          }
+        }}
+      />
+    </Box>
+  );
+}

--- a/src/frontend/magnify/src/components/profile/AvatarForm/index.ts
+++ b/src/frontend/magnify/src/components/profile/AvatarForm/index.ts
@@ -1,0 +1,1 @@
+export { default, AvatarFormProps } from './AvatarForm';

--- a/src/frontend/magnify/src/components/profile/DeleteAccountBlock/DeleteAccountBlock.stories.tsx
+++ b/src/frontend/magnify/src/components/profile/DeleteAccountBlock/DeleteAccountBlock.stories.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import DeleteAccountBlock from './DeleteAccountBlock';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'profile/DeleteAccountBlock',
+  component: DeleteAccountBlock,
+} as ComponentMeta<typeof DeleteAccountBlock>;
+
+const Template: ComponentStory<typeof DeleteAccountBlock> = () => <DeleteAccountBlock />;
+
+// create the template and 2 stories for variants blue and red
+export const Simple = Template.bind({});
+Simple.args = {};

--- a/src/frontend/magnify/src/components/profile/DeleteAccountBlock/DeleteAccountBlock.test.tsx
+++ b/src/frontend/magnify/src/components/profile/DeleteAccountBlock/DeleteAccountBlock.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+import DeleteAccountBlock from './DeleteAccountBlock';
+import userEvent from '@testing-library/user-event';
+
+describe('DeleteAccountBlock', () => {
+  it('should render the form and an explanation', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <IntlProvider locale="en">
+        <DeleteAccountBlock />
+      </IntlProvider>,
+    );
+
+    // Verify we get the explanation with appropriate warnings
+    const warning = screen.getByText('Danger zone');
+    expect(warning).toHaveStyle('color: rgb(255, 64, 64)');
+    expect(warning).toHaveStyle('text-transform: uppercase');
+    screen.getByText(/this action cannot be undone/);
+    screen.getByText(/will delete all your data/);
+
+    // Verify we have a dialog to confirm the deletion
+    const button = screen.getByRole('button', { name: 'Delete account' });
+    await user.click(button);
+    await screen.findByText('Confirm');
+
+    // Verify we can confirm the deletion
+    screen.getByRole('button', { name: 'Cancel' });
+    const confirmButton = screen.getByRole('button', { name: 'Confirm delete account' });
+    await user.click(confirmButton);
+  });
+});

--- a/src/frontend/magnify/src/components/profile/DeleteAccountBlock/DeleteAccountBlock.tsx
+++ b/src/frontend/magnify/src/components/profile/DeleteAccountBlock/DeleteAccountBlock.tsx
@@ -1,0 +1,123 @@
+import React, { useState } from 'react';
+import { Box, Button, Card, Heading, Layer, Text } from 'grommet';
+import { defineMessages, useIntl } from 'react-intl';
+
+const messages = defineMessages({
+  deleteAccountBlockTitle: {
+    defaultMessage: 'Delete account',
+    description: 'The title of the delete account block',
+    id: 'components.profile.deleteAccountBlock.title',
+  },
+  deleteAccountBlockDescription: {
+    defaultMessage: `You can delete your account. This will delete all your data and
+        your account will be removed from the system. Note that this action cannot be undone.`,
+    description: 'The description of the delete account block',
+    id: 'components.profile.deleteAccountBlock.description',
+  },
+  dangerZone: {
+    defaultMessage: 'Danger zone',
+    description: '"Danger zone" indication',
+    id: 'components.profile.deleteAccountBlock.dangerZone',
+  },
+  deleteAccountButtonLabel: {
+    defaultMessage: 'Delete account',
+    description: 'The label of the delete account button',
+    id: 'components.profile.deleteAccountBlock.deleteAccountButtonLabel',
+  },
+  confirmationWarning: {
+    defaultMessage: 'Are you sure you want to delete your account?',
+    description: 'The warning message before deleting the account',
+    id: 'components.profile.deleteAccountBlock.confirmationWarning',
+  },
+  cancelButtonLabel: {
+    defaultMessage: 'Cancel',
+    description: 'The label of the cancel button',
+    id: 'components.profile.deleteAccountBlock.cancelButtonLabel',
+  },
+  confirmationHeader: {
+    defaultMessage: 'Confirm',
+    description: 'The header of the confirmation layer',
+    id: 'components.profile.deleteAccountBlock.confirmationHeader',
+  },
+  confirmDeleteAccountButtonLabel: {
+    defaultMessage: 'Confirm delete account',
+    description: 'The label of the confirm delete account button',
+    id: 'components.profile.deleteAccountBlock.confirmDeleteAccountButtonLabel',
+  },
+});
+
+export default function DeleteAccountBlock() {
+  const intl = useIntl();
+  const [open, setOpen] = useState(false);
+
+  const handleClose = () => setOpen(false);
+  const handleOpen = () => setOpen(true);
+
+  const handleDelete = () => {
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <Card>
+        <Box margin="small">
+          <Box margin="large">
+            <Text color="status-error" style={{ textTransform: 'uppercase' }} weight="bold">
+              {intl.formatMessage(messages.dangerZone)}
+            </Text>
+            <Heading color="brand" level={3}>
+              {intl.formatMessage(messages.deleteAccountBlockTitle)}
+            </Heading>
+            <Text>{intl.formatMessage(messages.deleteAccountBlockDescription)}</Text>
+          </Box>
+          <Box margin={{ bottom: 'large', horizontal: 'large' }} direction="row">
+            <Button
+              primary
+              color="status-error"
+              label={intl.formatMessage(messages.deleteAccountButtonLabel)}
+              onClick={handleOpen}
+              role="button"
+            />
+          </Box>
+        </Box>
+      </Card>
+      {open && (
+        <Layer
+          id="confirmDelete"
+          position="center"
+          onClickOutside={handleClose}
+          onEsc={handleClose}
+        >
+          <Box pad="medium" gap="small" width="medium">
+            <Heading level={3} margin="none">
+              {intl.formatMessage(messages.confirmationHeader)}
+            </Heading>
+            <Text>{intl.formatMessage(messages.confirmationWarning)}</Text>
+            <Box
+              as="footer"
+              gap="small"
+              direction="row"
+              align="center"
+              justify="end"
+              pad={{ top: 'medium', bottom: 'small' }}
+            >
+              <Button
+                label={intl.formatMessage(messages.cancelButtonLabel)}
+                onClick={handleClose}
+                color="dark-3"
+                role="button"
+              />
+              <Button
+                label={intl.formatMessage(messages.confirmDeleteAccountButtonLabel)}
+                onClick={handleDelete}
+                primary
+                color="status-critical"
+                role="button"
+              />
+            </Box>
+          </Box>
+        </Layer>
+      )}
+    </>
+  );
+}

--- a/src/frontend/magnify/src/components/profile/DeleteAccountBlock/index.ts
+++ b/src/frontend/magnify/src/components/profile/DeleteAccountBlock/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DeleteAccountBlock';

--- a/src/frontend/magnify/src/components/profile/IdentityBlock/IdentityBlock.stories.tsx
+++ b/src/frontend/magnify/src/components/profile/IdentityBlock/IdentityBlock.stories.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import IdentityBlock from './IdentityBlock';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'profile/IdentityBlock',
+  component: IdentityBlock,
+} as ComponentMeta<typeof IdentityBlock>;
+
+const Template: ComponentStory<typeof IdentityBlock> = (args) => <IdentityBlock {...args} />;
+
+// create the template and 2 stories for variants blue and red
+export const Simple = Template.bind({});
+Simple.args = {
+  name: 'name',
+  username: 'username',
+  email: 'test@test.fr',
+  avatar: 'https://i.pravatar.cc/120?img=12',
+};

--- a/src/frontend/magnify/src/components/profile/IdentityBlock/IdentityBlock.test.tsx
+++ b/src/frontend/magnify/src/components/profile/IdentityBlock/IdentityBlock.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import IdentityBlock from './IdentityBlock';
+
+describe('IdentityBlock', () => {
+  it('should render the avatar and identity forms with right default values', async () => {
+    render(
+      <IntlProvider locale="en">
+        <IdentityBlock
+          name="John Doe"
+          username="johndoe3"
+          email="john.doe@example.com"
+          avatar="test.jpg"
+        />
+      </IntlProvider>,
+    );
+
+    const nameInput = screen.getByLabelText('Name');
+    const usernameInput = screen.getByLabelText('Username');
+    const emailInput = screen.getByLabelText('Email');
+    const saveButton = screen.getByText('Save');
+
+    expect(nameInput).toHaveValue('John Doe');
+    expect(usernameInput).toHaveValue('johndoe3');
+    expect(emailInput).toHaveValue('john.doe@example.com');
+    expect(saveButton).toBeDisabled();
+
+    const avatarImage = screen.getByTitle('Your avatar');
+    expect(avatarImage).toHaveStyle('background-image: url(test.jpg)');
+  });
+});

--- a/src/frontend/magnify/src/components/profile/IdentityBlock/IdentityBlock.test.tsx
+++ b/src/frontend/magnify/src/components/profile/IdentityBlock/IdentityBlock.test.tsx
@@ -16,9 +16,9 @@ describe('IdentityBlock', () => {
       </IntlProvider>,
     );
 
-    const nameInput = screen.getByLabelText('Name');
-    const usernameInput = screen.getByLabelText('Username');
-    const emailInput = screen.getByLabelText('Email');
+    const nameInput = screen.getByLabelText('Name*');
+    const usernameInput = screen.getByLabelText('Username*');
+    const emailInput = screen.getByLabelText('Email*');
     const saveButton = screen.getByText('Save');
 
     expect(nameInput).toHaveValue('John Doe');

--- a/src/frontend/magnify/src/components/profile/IdentityBlock/IdentityBlock.tsx
+++ b/src/frontend/magnify/src/components/profile/IdentityBlock/IdentityBlock.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Box, Card } from 'grommet';
+import AvatarForm from '../AvatarForm';
+import IdentityForm from '../IdentityForm';
+
+export interface IdentityBlockProps {
+  name: string;
+  username: string;
+  email: string;
+  avatar?: string;
+}
+
+export default function IdentityBlock({ name, username, email, avatar }: IdentityBlockProps) {
+  return (
+    <Card>
+      <Box direction="row">
+        <Box margin={{ vertical: 'auto', horizontal: 'large' }}>
+          <AvatarForm src={avatar} />
+        </Box>
+        <Box margin="large" style={{ flexGrow: 1 }}>
+          <IdentityForm name={name} email={email} username={username} />
+        </Box>
+      </Box>
+    </Card>
+  );
+}

--- a/src/frontend/magnify/src/components/profile/IdentityBlock/index.ts
+++ b/src/frontend/magnify/src/components/profile/IdentityBlock/index.ts
@@ -1,0 +1,1 @@
+export { default, IdentityBlockProps } from './IdentityBlock';

--- a/src/frontend/magnify/src/components/profile/IdentityForm/IdentityForm.stories.tsx
+++ b/src/frontend/magnify/src/components/profile/IdentityForm/IdentityForm.stories.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import IdentityForm from './IdentityForm';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'profile/IdentityForm',
+  component: IdentityForm,
+} as ComponentMeta<typeof IdentityForm>;
+
+const Template: ComponentStory<typeof IdentityForm> = (args) => <IdentityForm {...args} />;
+
+// create the template and 2 stories for variants blue and red
+export const Simple = Template.bind({});
+Simple.args = {
+  name: 'name',
+  username: 'username',
+  email: 'test@test.fr',
+};

--- a/src/frontend/magnify/src/components/profile/IdentityForm/IdentityForm.test.tsx
+++ b/src/frontend/magnify/src/components/profile/IdentityForm/IdentityForm.test.tsx
@@ -14,9 +14,9 @@ describe('IdentityForm', () => {
       </IntlProvider>,
     );
 
-    const nameInput = screen.getByLabelText('Name');
-    const usernameInput = screen.getByLabelText('Username');
-    const emailInput = screen.getByLabelText('Email');
+    const nameInput = screen.getByRole('textbox', { name: 'Name *' });
+    const usernameInput = screen.getByRole('textbox', { name: 'Username *' });
+    const emailInput = screen.getByRole('textbox', { name: 'Email *' });
 
     // Save button is initially disabled (no modification)
     const saveButton = screen.getByText('Save');
@@ -24,14 +24,14 @@ describe('IdentityForm', () => {
 
     // Name field and validators
     await userEvent.clear(nameInput);
-    await screen.findByText('Name is required');
+    await screen.findByText('This field is required');
     await userEvent.type(nameInput, 'John Watson');
 
     // Username field and validators
     const invalidErrMessage =
       'Username is invalid, it should have between 3 and 16 letters, numbers or underscores';
     await userEvent.clear(usernameInput);
-    await screen.findByText('Username is required');
+    await screen.findByText('This field is required');
     await userEvent.type(usernameInput, '@test');
     await userEvent.clear(usernameInput);
     await userEvent.type(usernameInput, '2t');
@@ -44,7 +44,7 @@ describe('IdentityForm', () => {
 
     // Email field and validators
     await userEvent.clear(emailInput);
-    await screen.findByText('Email is required');
+    await screen.findByText('This field is required');
     await userEvent.type(emailInput, 'watson@test');
     await screen.findByText('Email is invalid');
     await userEvent.type(emailInput, '.fr');

--- a/src/frontend/magnify/src/components/profile/IdentityForm/IdentityForm.test.tsx
+++ b/src/frontend/magnify/src/components/profile/IdentityForm/IdentityForm.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+import IdentityForm from './IdentityForm';
+
+describe('IdentityForm', () => {
+  it('should render a form that can be filled and submited', async () => {
+    userEvent.setup();
+
+    render(
+      <IntlProvider locale="en">
+        <IdentityForm name="John Doe" username="johndoe3" email="john.doe@test.fr" />
+      </IntlProvider>,
+    );
+
+    const nameInput = screen.getByLabelText('Name');
+    const usernameInput = screen.getByLabelText('Username');
+    const emailInput = screen.getByLabelText('Email');
+
+    // Save button is initially disabled (no modification)
+    const saveButton = screen.getByText('Save');
+    expect(saveButton).toBeDisabled();
+
+    // Name field and validators
+    await userEvent.clear(nameInput);
+    await screen.findByText('Name is required');
+    await userEvent.type(nameInput, 'John Watson');
+
+    // Username field and validators
+    const invalidErrMessage =
+      'Username is invalid, it should have between 3 and 16 letters, numbers or underscores';
+    await userEvent.clear(usernameInput);
+    await screen.findByText('Username is required');
+    await userEvent.type(usernameInput, '@test');
+    await userEvent.clear(usernameInput);
+    await userEvent.type(usernameInput, '2t');
+    await screen.findByText(invalidErrMessage);
+    await userEvent.clear(usernameInput);
+    await userEvent.type(usernameInput, 'atoolongusername7azertyui');
+    await screen.findByText(invalidErrMessage);
+    await userEvent.clear(usernameInput);
+    await userEvent.type(usernameInput, 'JoshWatson3');
+
+    // Email field and validators
+    await userEvent.clear(emailInput);
+    await screen.findByText('Email is required');
+    await userEvent.type(emailInput, 'watson@test');
+    await screen.findByText('Email is invalid');
+    await userEvent.type(emailInput, '.fr');
+    expect(screen.queryByText('Email is invalid')).not.toBeInTheDocument();
+
+    // Submit the form
+    expect(saveButton).toBeEnabled();
+    await userEvent.click(saveButton);
+  });
+});

--- a/src/frontend/magnify/src/components/profile/IdentityForm/IdentityForm.tsx
+++ b/src/frontend/magnify/src/components/profile/IdentityForm/IdentityForm.tsx
@@ -1,0 +1,158 @@
+import { Box, Button } from 'grommet';
+import React, { useState } from 'react';
+import TextField from '../../design-system/TextField';
+import validator from 'validator';
+import { defineMessages, useIntl } from 'react-intl';
+
+export interface IdentityFormProps {
+  name: string;
+  username: string;
+  email: string;
+}
+
+interface IdentityFormValues {
+  name: string;
+  username: string;
+  email: string;
+}
+
+interface IdentityFormErrors {
+  name: string[];
+  username: string[];
+  email: string[];
+}
+
+const messages = defineMessages({
+  nameLabel: {
+    defaultMessage: 'Name',
+    description: 'The label for the name field',
+    id: 'components.profile.identityForm.nameLabel',
+  },
+  nameRequired: {
+    defaultMessage: 'Name is required',
+    description: 'The error message for the name field',
+    id: 'components.profile.identityForm.nameRequired',
+  },
+  usernameLabel: {
+    defaultMessage: 'Username',
+    description: 'The label for the username field',
+    id: 'components.profile.identityForm.usernameLabel',
+  },
+  usernameRequired: {
+    defaultMessage: 'Username is required',
+    description: 'The error message for the username field',
+    id: 'components.profile.identityForm.usernameRequired',
+  },
+  usernameInvalid: {
+    defaultMessage:
+      'Username is invalid, it should have between 3 and 16 letters, numbers or underscores',
+    description: 'The error message for the username field',
+    id: 'components.profile.identityForm.usernameInvalid',
+  },
+  emailLabel: {
+    defaultMessage: 'Email',
+    description: 'The label for the email field',
+    id: 'components.profile.identityForm.emailLabel',
+  },
+  emailRequired: {
+    defaultMessage: 'Email is required',
+    description: 'The error message for the email field',
+    id: 'components.profile.identityForm.emailRequired',
+  },
+  emailInvalid: {
+    defaultMessage: 'Email is invalid',
+    description: 'The error message for the email field',
+    id: 'components.profile.identityForm.emailInvalid',
+  },
+  submitButtonLabel: {
+    defaultMessage: 'Save',
+    description: 'The label for the submit button',
+    id: 'components.profile.identityForm.submitButtonLabel',
+  },
+});
+
+export default function IdentityForm({ name, username, email }: IdentityFormProps) {
+  const intl = useIntl();
+  const [formValues, setFormValues] = useState<IdentityFormValues>({ name, username, email });
+  const [formErrors, setFormErrors] = useState<IdentityFormErrors>({
+    name: [],
+    username: [],
+    email: [],
+  });
+
+  const modified =
+    name !== formValues.name || username !== formValues.username || email !== formValues.email;
+  const valid = Object.values(formErrors).every((errors) => errors.length === 0);
+
+  const validate = (formState: IdentityFormValues) => {
+    const errors: IdentityFormErrors = {
+      name: [],
+      username: [],
+      email: [],
+    };
+
+    if (!formState.name || formState.name.length < 1)
+      errors.name.push(intl.formatMessage(messages.nameRequired));
+    if (!formState.username || formState.username.length < 1)
+      errors.username.push(intl.formatMessage(messages.usernameRequired));
+    else if (!validator.matches(formState.username, /^[a-zA-Z0-9_]{3,16}$/))
+      errors.username.push(intl.formatMessage(messages.usernameInvalid));
+    if (!formState.email || formState.email.length < 1)
+      errors.email.push(intl.formatMessage(messages.emailRequired));
+    else if (!validator.isEmail(formState.email))
+      errors.email.push(intl.formatMessage(messages.emailInvalid));
+
+    setFormErrors(errors);
+
+    return Object.values(errors).every((errors) => errors.length === 0);
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value, name } = e.target;
+    const newFormState = { ...formValues, [name as keyof IdentityFormValues]: value };
+    setFormValues(newFormState);
+    validate(newFormState);
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    console.log('submit', formValues);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <TextField
+        label={intl.formatMessage(messages.nameLabel)}
+        name="name"
+        value={formValues.name}
+        errors={formErrors.name}
+        onChange={handleChange}
+        margin={{ bottom: 'small' }}
+      />
+      <TextField
+        label={intl.formatMessage(messages.usernameLabel)}
+        name="username"
+        value={formValues.username}
+        errors={formErrors.username}
+        onChange={handleChange}
+        margin={{ bottom: 'small' }}
+      />
+      <TextField
+        label={intl.formatMessage(messages.emailLabel)}
+        name="email"
+        value={formValues.email}
+        errors={formErrors.email}
+        onChange={handleChange}
+        margin={{ bottom: 'small' }}
+      />
+      <Box direction="row" justify="end" margin={{ top: 'small' }}>
+        <Button
+          primary
+          label={intl.formatMessage(messages.submitButtonLabel)}
+          disabled={!modified || !valid}
+          type="submit"
+        />
+      </Box>
+    </form>
+  );
+}

--- a/src/frontend/magnify/src/components/profile/IdentityForm/index.ts
+++ b/src/frontend/magnify/src/components/profile/IdentityForm/index.ts
@@ -1,0 +1,1 @@
+export { default, IdentityFormProps } from './IdentityForm';

--- a/src/frontend/magnify/src/components/profile/PasswordUpdateBlock/PasswordUpdateBlock.stories.tsx
+++ b/src/frontend/magnify/src/components/profile/PasswordUpdateBlock/PasswordUpdateBlock.stories.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import PasswordUpdateBlock from './PasswordUpdateBlock';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'profile/PasswordUpdateBlock',
+  component: PasswordUpdateBlock,
+} as ComponentMeta<typeof PasswordUpdateBlock>;
+
+const Template: ComponentStory<typeof PasswordUpdateBlock> = () => <PasswordUpdateBlock />;
+
+// create the template and 2 stories for variants blue and red
+export const Simple = Template.bind({});
+Simple.args = {};

--- a/src/frontend/magnify/src/components/profile/PasswordUpdateBlock/PasswordUpdateBlock.test.tsx
+++ b/src/frontend/magnify/src/components/profile/PasswordUpdateBlock/PasswordUpdateBlock.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+import PasswordUpdateBlock from './PasswordUpdateBlock';
+
+describe('PasswordUpdateBlock', () => {
+  it('should render the form and an explanation', () => {
+    render(
+      <IntlProvider locale="en">
+        <PasswordUpdateBlock />
+      </IntlProvider>,
+    );
+
+    // Verify we get the form
+    screen.getByLabelText('Previous password*') as HTMLInputElement;
+    screen.getByLabelText('New password*') as HTMLInputElement;
+    screen.getByLabelText('Confirm new password*') as HTMLInputElement;
+
+    // Verify we get the explanation
+    screen.getByText('Update password');
+    screen.getByText(/choose a password with more than 8 characters/);
+    screen.getByText(/mix of letters, numbers and symbols/);
+  });
+});

--- a/src/frontend/magnify/src/components/profile/PasswordUpdateBlock/PasswordUpdateBlock.tsx
+++ b/src/frontend/magnify/src/components/profile/PasswordUpdateBlock/PasswordUpdateBlock.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Box, Card, Grid, Heading, Text } from 'grommet';
+import PasswordUpdateForm from '../PasswordUpdateForm';
+import { defineMessages, useIntl } from 'react-intl';
+
+const messages = defineMessages({
+  updatePasswordBlockTitle: {
+    defaultMessage: 'Update password',
+    description: 'The title of the password update block',
+    id: 'components.profile.passwordUpdateBlock.title',
+  },
+  updatePasswordBlockDescription: {
+    defaultMessage: `Your password is used to authenticate your account and 
+        to protect your data. To make it stronger, choose a password with more 
+        than 8 characters, including a mix of letters, numbers and symbols.`,
+    description: 'The description of the password update block',
+    id: 'components.profile.passwordUpdateBlock.description',
+  },
+});
+
+export default function PasswordUpdateBlock() {
+  const intl = useIntl();
+
+  return (
+    <Card>
+      <Box margin="small" direction="row">
+        <Grid
+          columns={['flex', 'flex']}
+          rows={['flex']}
+          areas={[
+            { name: 'header', start: [0, 0], end: [0, 0] },
+            { name: 'body', start: [1, 0], end: [1, 0] },
+          ]}
+          gap="small"
+        >
+          <Box gridArea="header" margin="large">
+            <Heading color="brand" level={3}>
+              {intl.formatMessage(messages.updatePasswordBlockTitle)}
+            </Heading>
+            <Text>{intl.formatMessage(messages.updatePasswordBlockDescription)}</Text>
+          </Box>
+
+          <Box gridArea="body" margin="large">
+            <PasswordUpdateForm />
+          </Box>
+        </Grid>
+      </Box>
+    </Card>
+  );
+}

--- a/src/frontend/magnify/src/components/profile/PasswordUpdateBlock/index.ts
+++ b/src/frontend/magnify/src/components/profile/PasswordUpdateBlock/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PasswordUpdateBlock';

--- a/src/frontend/magnify/src/components/profile/PasswordUpdateForm/PasswordUpdateForm.stories.tsx
+++ b/src/frontend/magnify/src/components/profile/PasswordUpdateForm/PasswordUpdateForm.stories.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import PasswordUpdateForm from './PasswordUpdateForm';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'profile/PasswordUpdateForm',
+  component: PasswordUpdateForm,
+} as ComponentMeta<typeof PasswordUpdateForm>;
+
+const Template: ComponentStory<typeof PasswordUpdateForm> = () => <PasswordUpdateForm />;
+
+// create the template and 2 stories for variants blue and red
+export const Simple = Template.bind({});

--- a/src/frontend/magnify/src/components/profile/PasswordUpdateForm/PasswordUpdateForm.test.tsx
+++ b/src/frontend/magnify/src/components/profile/PasswordUpdateForm/PasswordUpdateForm.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+import PasswordUpdateForm from './PasswordUpdateForm';
+
+describe('PasswordUpdateForm', () => {
+  it('should render a form that can be filled and submited', async () => {
+    userEvent.setup();
+
+    render(
+      <IntlProvider locale="en">
+        <PasswordUpdateForm />
+      </IntlProvider>,
+    );
+
+    const previousPasswordInput = screen.getByLabelText('Previous password*') as HTMLInputElement;
+    const newPasswordInput = screen.getByLabelText('New password*') as HTMLInputElement;
+    const confirmPasswordInput = screen.getByLabelText('Confirm new password*') as HTMLInputElement;
+
+    // initially the form is empty
+    expect(previousPasswordInput.value).toBe('');
+    expect(newPasswordInput.value).toBe('');
+    expect(confirmPasswordInput.value).toBe('');
+
+    // Save button is initially disabled (no modification)
+    const saveButton = screen.getByText('Save new password');
+    expect(saveButton).toBeDisabled();
+
+    // Type previous password
+    await userEvent.type(previousPasswordInput, 'oldPassword');
+    expect(saveButton).toBeDisabled();
+
+    await userEvent.type(newPasswordInput, 'newPassword');
+    expect(saveButton).toBeDisabled();
+
+    await userEvent.type(confirmPasswordInput, 'new');
+    await screen.findByText("New password and it's confirmation do not match");
+    expect(saveButton).toBeDisabled();
+    await userEvent.type(confirmPasswordInput, 'Password');
+
+    // Submit the form
+    expect(saveButton).toBeEnabled();
+    await userEvent.click(saveButton);
+  });
+});

--- a/src/frontend/magnify/src/components/profile/PasswordUpdateForm/PasswordUpdateForm.tsx
+++ b/src/frontend/magnify/src/components/profile/PasswordUpdateForm/PasswordUpdateForm.tsx
@@ -1,0 +1,115 @@
+import { Box, Button } from 'grommet';
+import React from 'react';
+import { defineMessages, useIntl } from 'react-intl';
+import useFormState from '../../../hooks/useFormState';
+import { validationMessages } from '../../../i18n/Messages';
+import { TextField } from '../../design-system';
+
+const messages = defineMessages({
+  previousPasswordLabel: {
+    defaultMessage: 'Previous password',
+    description: 'The label for the previous password field',
+    id: 'components.profile.passwordUpdateForm.previousPasswordLabel',
+  },
+  newPasswordLabel: {
+    defaultMessage: 'New password',
+    description: 'The label for the new password field',
+    id: 'components.profile.passwordUpdateForm.newPasswordLabel',
+  },
+  confirmNewPasswordLabel: {
+    defaultMessage: 'Confirm new password',
+    description: 'The label for the confirm new password field',
+    id: 'components.profile.passwordUpdateForm.confirmNewPasswordLabel',
+  },
+  confirmDoesNotMatch: {
+    defaultMessage: "New password and it's confirmation do not match",
+    description: 'The error message for the confirm new password field',
+    id: 'components.profile.passwordUpdateForm.confirmDoesNotMatch',
+  },
+  submitButtonLabel: {
+    defaultMessage: 'Save new password',
+    description: 'The label for the submit button on the password update form',
+    id: 'components.profile.passwordUpdateForm.submitButtonLabel',
+  },
+});
+
+export default function PasswordUpdateForm() {
+  const intl = useIntl();
+  const { values, errors, modified, isModified, isValid, setValue } = useFormState(
+    { previousPassword: '', newPassword: '', confirmNewPassword: '' },
+    {
+      previousPassword: (value: string) => {
+        if (!value || value.length < 1) return [intl.formatMessage(validationMessages.required)];
+        return [];
+      },
+      newPassword: (value: string) => {
+        if (!value || value.length < 1) return [intl.formatMessage(validationMessages.required)];
+        return [];
+      },
+      confirmNewPassword: (value: string, { newPassword }: { newPassword: string }) => {
+        if (!value || value.length < 1) return [intl.formatMessage(validationMessages.required)];
+        if (value !== newPassword && newPassword.length > 0)
+          return [intl.formatMessage(messages.confirmDoesNotMatch)];
+        return [];
+      },
+    },
+  );
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(
+      event.target.name as 'previousPassword' | 'newPassword' | 'confirmNewPassword',
+      event.target.value,
+    );
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    console.log('submit', values);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <TextField
+        label={intl.formatMessage(messages.previousPasswordLabel)}
+        name="previousPassword"
+        value={values.previousPassword}
+        errors={errors.previousPassword}
+        displayErrors={modified.previousPassword}
+        onChange={handleChange}
+        margin={{ bottom: 'small' }}
+        type="password"
+        required
+      />
+      <TextField
+        label={intl.formatMessage(messages.newPasswordLabel)}
+        name="newPassword"
+        value={values.newPassword}
+        errors={errors.newPassword}
+        displayErrors={modified.newPassword}
+        onChange={handleChange}
+        margin={{ bottom: 'small' }}
+        type="password"
+        required
+      />
+      <TextField
+        label={intl.formatMessage(messages.confirmNewPasswordLabel)}
+        name="confirmNewPassword"
+        value={values.confirmNewPassword}
+        errors={errors.confirmNewPassword}
+        displayErrors={modified.confirmNewPassword}
+        onChange={handleChange}
+        margin={{ bottom: 'small' }}
+        type="password"
+        required
+      />
+      <Box direction="row" justify="end" margin={{ top: 'small' }}>
+        <Button
+          primary
+          label={intl.formatMessage(messages.submitButtonLabel)}
+          disabled={!isModified || !isValid}
+          type="submit"
+        />
+      </Box>
+    </form>
+  );
+}

--- a/src/frontend/magnify/src/components/profile/PasswordUpdateForm/index.ts
+++ b/src/frontend/magnify/src/components/profile/PasswordUpdateForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PasswordUpdateForm';

--- a/src/frontend/magnify/src/components/profile/index.ts
+++ b/src/frontend/magnify/src/components/profile/index.ts
@@ -1,1 +1,2 @@
 export { default as AvatarForm, AvatarFormProps } from './AvatarForm';
+export { default as IdentityForm, IdentityFormProps } from './IdentityForm';

--- a/src/frontend/magnify/src/components/profile/index.ts
+++ b/src/frontend/magnify/src/components/profile/index.ts
@@ -1,4 +1,5 @@
 export { default as AvatarForm, AvatarFormProps } from './AvatarForm';
+export { default as DeleteAccountBlock } from './DeleteAccountBlock';
 export { default as IdentityBlock, IdentityBlockProps } from './IdentityBlock';
 export { default as IdentityForm, IdentityFormProps } from './IdentityForm';
 export { default as PasswordUpdateBlock } from './PasswordUpdateBlock';

--- a/src/frontend/magnify/src/components/profile/index.ts
+++ b/src/frontend/magnify/src/components/profile/index.ts
@@ -1,2 +1,3 @@
 export { default as AvatarForm, AvatarFormProps } from './AvatarForm';
+export { default as IdentityBlock, IdentityBlockProps } from './IdentityBlock';
 export { default as IdentityForm, IdentityFormProps } from './IdentityForm';

--- a/src/frontend/magnify/src/components/profile/index.ts
+++ b/src/frontend/magnify/src/components/profile/index.ts
@@ -1,3 +1,4 @@
 export { default as AvatarForm, AvatarFormProps } from './AvatarForm';
 export { default as IdentityBlock, IdentityBlockProps } from './IdentityBlock';
 export { default as IdentityForm, IdentityFormProps } from './IdentityForm';
+export { default as PasswordUpdateForm } from './PasswordUpdateForm';

--- a/src/frontend/magnify/src/components/profile/index.ts
+++ b/src/frontend/magnify/src/components/profile/index.ts
@@ -1,4 +1,5 @@
 export { default as AvatarForm, AvatarFormProps } from './AvatarForm';
 export { default as IdentityBlock, IdentityBlockProps } from './IdentityBlock';
 export { default as IdentityForm, IdentityFormProps } from './IdentityForm';
+export { default as PasswordUpdateBlock } from './PasswordUpdateBlock';
 export { default as PasswordUpdateForm } from './PasswordUpdateForm';

--- a/src/frontend/magnify/src/components/profile/index.ts
+++ b/src/frontend/magnify/src/components/profile/index.ts
@@ -1,0 +1,1 @@
+export { default as AvatarForm, AvatarFormProps } from './AvatarForm';

--- a/src/frontend/magnify/src/hooks/useFormState.ts
+++ b/src/frontend/magnify/src/hooks/useFormState.ts
@@ -1,0 +1,93 @@
+import { useCallback, useState } from 'react';
+
+type Validators<T> = {
+  [key in keyof T]: (value: string, otherValues: T) => string[] | null;
+};
+
+interface UseFormState<T> {
+  /**
+   * The current form state, with values for each field.
+   */
+  values: T;
+  /**
+   * The errors on each field
+   */
+  errors: Record<keyof T, string[]>;
+  /**
+   * Whether each field is modified
+   * It may be used to display errors only when the field is modified, or to
+   * optimize the partial update requests
+   */
+  modified: Record<keyof T, boolean>;
+  /**
+   * A callback to update a single field
+   */
+  setValue: (key: keyof T, value: string) => void;
+  /**
+   * Are they errors ? (if so, the form is invalid)
+   */
+  isValid: boolean;
+  /**
+   * Are values diferrent from initial values ? (if so, the form is modified)
+   */
+  isModified: boolean;
+}
+
+/**
+ * This hook is used to manage the state of a form.
+ * It is used to validate the form, and to update the values.
+ *
+ * @param initialState The initial state of the form
+ * @param validators An object describing the validators for each field
+ *      For each field, profide a function returning:
+ *          - [] if the field is valid
+ *          - ["error message"] if the field as an error
+ *          - ["err1", "err2"] if the field as multiple errors
+ *      As input, each validator receive the new value of the field, and the values of all other fields.
+ * @returns UseFormState
+ */
+export default function useFormState<T extends Record<string, string>>(
+  initialState: T,
+  validators: Validators<T>,
+): UseFormState<T> {
+  const [values, setValues] = useState<T>(initialState);
+  const [errors, setErrors] = useState(
+    Object.fromEntries(Object.keys(initialState).map((key) => [key, [] as string[]])) as Record<
+      keyof T,
+      string[]
+    >,
+  );
+
+  const setValue = useCallback((name: keyof T, value: string) => {
+    // Reminder: setters are kind of async, so we need to use a callback to update the state,
+    // and to access the new value for error validation, the validation must be done
+    // inside too
+    setValues((pValues: T) => {
+      const newValues = { ...pValues, [name]: value };
+      const newErrors = Object.fromEntries(
+        Object.keys(validators).map((key) => {
+          return [key, validators[key as keyof T](newValues[key as keyof T], newValues)];
+        }),
+      ) as Record<keyof T, string[]>;
+
+      setErrors(newErrors);
+      return newValues;
+    });
+  }, []);
+
+  const modified = Object.fromEntries(
+    Object.keys(values).map((key) => [
+      key,
+      values[key as keyof T] !== initialState[key as keyof T],
+    ]),
+  ) as Record<keyof T, boolean>;
+
+  return {
+    values,
+    setValue,
+    errors,
+    modified,
+    isValid: Object.values(errors).every((error) => (error as string[]).length === 0),
+    isModified: Object.values(modified).some((modified) => modified),
+  };
+}

--- a/src/frontend/magnify/src/i18n/Messages/index.ts
+++ b/src/frontend/magnify/src/i18n/Messages/index.ts
@@ -1,0 +1,1 @@
+export * from './validationMessages';

--- a/src/frontend/magnify/src/i18n/Messages/validationMessages.ts
+++ b/src/frontend/magnify/src/i18n/Messages/validationMessages.ts
@@ -1,0 +1,9 @@
+import { defineMessages } from 'react-intl';
+
+export const validationMessages = defineMessages({
+  required: {
+    id: 'validationMessages.required',
+    description: 'Messages shown when a field is required but the user did not provide any value',
+    defaultMessage: 'This field is required',
+  },
+});

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -3318,10 +3318,10 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-"@testing-library/user-event@14.2.0":
-  version "14.2.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.2.0.tgz#8293560f8f80a00383d6c755ec3e0b918acb1683"
-  integrity sha512-+hIlG4nJS6ivZrKnOP7OGsDu9Fxmryj9vCl8x0ZINtTJcCHs2zLsYif5GzuRiBF2ck5GZG2aQr7Msg+EHlnYVQ==
+"@testing-library/user-event@14.2.1":
+  version "14.2.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.2.1.tgz#8c5ff2d004544bb2220e1d864f7267fe7eb6c556"
+  integrity sha512-HOr1QiODrq+0j9lKU5i10y9TbhxMBMRMGimNx10asdmau9cb8Xb1Vyg0GvTwyIL2ziQyh2kAloOtAQFBQVuecA==
 
 "@testing-library/user-event@^13.2.1":
   version "13.5.0"
@@ -3329,11 +3329,6 @@
   integrity sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==
   dependencies:
     "@babel/runtime" "^7.12.5"
-
-"@testing-library/user-event@^14.2.1":
-  version "14.2.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.2.1.tgz#8c5ff2d004544bb2220e1d864f7267fe7eb6c556"
-  integrity sha512-HOr1QiODrq+0j9lKU5i10y9TbhxMBMRMGimNx10asdmau9cb8Xb1Vyg0GvTwyIL2ziQyh2kAloOtAQFBQVuecA==
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -3819,6 +3814,11 @@
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
+
+"@types/validator@13.7.3":
+  version "13.7.3"
+  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.7.3.tgz#3193c0a3c03a7d1189016c62b4fba4b149ef5e33"
+  integrity sha512-DNviAE5OUcZ5s+XEQHRhERLg8fOp8gSgvyJ4aaFASx5wwaObm+PBwTIMXiOFm1QrSee5oYwEAYb7LMzX2O88gA==
 
 "@types/webpack-env@^1.16.0":
   version "1.17.0"
@@ -15433,7 +15433,7 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-validator@^13.7.0:
+validator@13.7.0:
   version "13.7.0"
   resolved "https://registry.yarnpkg.com/validator/-/validator-13.7.0.tgz#4f9658ba13ba8f3d82ee881d3516489ea85c0857"
   integrity sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -3330,6 +3330,11 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
 
+"@testing-library/user-event@^14.2.1":
+  version "14.2.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.2.1.tgz#8c5ff2d004544bb2220e1d864f7267fe7eb6c556"
+  integrity sha512-HOr1QiODrq+0j9lKU5i10y9TbhxMBMRMGimNx10asdmau9cb8Xb1Vyg0GvTwyIL2ziQyh2kAloOtAQFBQVuecA==
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -15427,6 +15432,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+validator@^13.7.0:
+  version "13.7.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.7.0.tgz#4f9658ba13ba8f3d82ee881d3516489ea85c0857"
+  integrity sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## Purpose

This add the components and main blocks from the profile page. The "linked accounts" was skipped as it is still under discussion on whether or not we should include GAFAM providers

## Proposal

This add following components

- Forms
  - AvatarForm
  - IdentityForm (name, username, email)
  - PasswordUpdateForm
- Blocks: a block is a section of the page, grouping some forms/controls
  - IdentityBlock (grouping avatar and identity form)
  - PasswordUpdateBlock 
  - DeleteAccountBlock

But also some genericity, with a custom TextField component, and a generic hook to handle the form state

Finaly, here are some screenshots of the 3 blocks
 
![Screenshot from 2022-06-22 12-01-28](https://user-images.githubusercontent.com/25184106/175002318-7ec58d56-52ab-4e28-8384-dc792a71cb3a.png)

