### PR TITLE
💚(circleci) fix npm job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -555,7 +555,7 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/fun/.npmrc
       - run:
           name: Publish package
-          command: npm publish src/frontend/magnify
+          command: npm publish src/frontend/magnify/
 
 workflows:
   version: 2


### PR DESCRIPTION
## Purpose

We recently switched to new circle node images and upgraded to node 16 which has also upgraded npm to version 8.11.0. This has broken the publish command so we have to fix it.

## Proposal

Copy of @jbpenrath's fix on richie: https://github.com/openfun/richie/pull/1734/commits/ad1e22f10cfa05ec76f594644301a38b6a00ba4d
