### PR TITLE
🐛(serializers) fix setting user password upon creation

### DIFF
--- a/src/magnify/apps/core/serializers/users.py
+++ b/src/magnify/apps/core/serializers/users.py
@@ -1,4 +1,6 @@
 """Serializers for the core Magnify app."""
+from django.contrib.auth.hashers import make_password
+
 from rest_framework import serializers
 
 from magnify.apps.core import models
@@ -33,9 +35,8 @@ class RegistrationSerializer(serializers.ModelSerializer):
 
     def save(self, *args, **kwargs):
         """Create the user then set the passsword."""
-        user = super().save(*args, **kwargs)
-        user.set_password(self.validated_data["password"])
-        return user
+        kwargs["password"] = make_password(self.validated_data["password"])
+        return super().save(*args, **kwargs)
 
 
 # pylint: disable=abstract-method

--- a/tests/apps/core/test_api_users.py
+++ b/tests/apps/core/test_api_users.py
@@ -3,6 +3,8 @@ Tests for Users API endpoints in Magnify's core app.
 """
 from unittest import mock
 
+from django.contrib.auth.hashers import check_password
+
 from rest_framework.test import APITestCase
 from rest_framework_simplejwt.tokens import AccessToken
 
@@ -234,7 +236,6 @@ class UsersApiTestCase(APITestCase):
                 "password": "mypassword",
             },
         )
-
         self.assertEqual(response.status_code, 201)
         self.assertEqual(User.objects.count(), 1)
 
@@ -242,6 +243,9 @@ class UsersApiTestCase(APITestCase):
         self.assertEqual(user.email, "thomas.jeffersion@example.com")
         self.assertEqual(user.name, "Thomas Jefferson")
         self.assertEqual(user.username, "thomas")
+
+        self.assertIn("pbkdf2_sha256", user.password)
+        self.assertTrue(check_password("mypassword", user.password))
 
     def test_api_users_create_authenticated_successful(self):
         """Authenticated users should be able to create users."""


### PR DESCRIPTION
## Purpose

We forgot to call save on the user instance after setting its password which resulted in the password being set without hashing. It was not functional.

## Proposal

The test had a blind spot and should check that the password was correctly set.

Instead of adding a call to  `save` after setting the password using `set_password`, we compute the encoded password directly and pass it to the save method so that we don't need to save the user twice.

More importantly, it also avoids saving the raw password to database in the first save, only to overwrite it in the second save :sweat_smile: 