### PR TITLE
🎨(backend) use REST style api path for RoomUser and RoomGroup

### DIFF
--- a/src/magnify/apps/core/permissions.py
+++ b/src/magnify/apps/core/permissions.py
@@ -57,26 +57,6 @@ class IsObjectAdministrator(permissions.BasePermission):
         )
 
 
-class IsRelatedRoomAdministrator(permissions.BasePermission):
-    """
-    Permissions for an object related to a room that can only be updated by room administrators.
-    """
-
-    def has_permission(self, request, view):
-        """Only allow authenticated users."""
-        return request.user.is_authenticated
-
-    def has_object_permission(self, request, view, obj):
-        """Check that the logged-in user is adminisrator of the linked room."""
-        user = request.user
-        return user.is_authenticated and (
-            obj.room.user_relations.filter(is_administrator=True, user=user)
-            or obj.room.group_relations.filter(
-                is_administrator=True, group__user_relations__user=user
-            )
-        )
-
-
 class IsRoomAdministrator(permissions.BasePermission):
     """
     Permissions for a room that can only be updated by room administrators.

--- a/src/magnify/apps/core/permissions.py
+++ b/src/magnify/apps/core/permissions.py
@@ -75,3 +75,23 @@ class IsRelatedRoomAdministrator(permissions.BasePermission):
                 is_administrator=True, group__user_relations__user=user
             )
         )
+
+
+class IsRoomAdministrator(permissions.BasePermission):
+    """
+    Permissions for a room that can only be updated by room administrators.
+    """
+
+    def has_permission(self, request, view):
+        """Only allow authenticated users."""
+        return request.user.is_authenticated
+
+    def has_object_permission(self, request, view, obj):
+        """Check that the logged-in user is adminisrator of the linked room."""
+        user = request.user
+        return user.is_authenticated and (
+            obj.user_relations.filter(is_administrator=True, user=user)
+            or obj.group_relations.filter(
+                is_administrator=True, group__user_relations__user=user
+            )
+        )

--- a/src/magnify/apps/core/urls.py
+++ b/src/magnify/apps/core/urls.py
@@ -25,11 +25,6 @@ SchemaView = get_schema_view(
 
 router = DefaultRouter()
 router.register("rooms", api.RoomViewSet, basename="rooms")
-router.register(
-    "room-group-relations",
-    api.RoomGroupViewSet,
-    basename="room_group_relations",
-)
 router.register("users", api.UserViewSet, basename="users")
 
 # To appear on the swagger URL,

--- a/src/magnify/apps/core/urls.py
+++ b/src/magnify/apps/core/urls.py
@@ -26,9 +26,6 @@ SchemaView = get_schema_view(
 router = DefaultRouter()
 router.register("rooms", api.RoomViewSet, basename="rooms")
 router.register(
-    "room-user-relations", api.RoomUserViewSet, basename="room_user_relations"
-)
-router.register(
     "room-group-relations",
     api.RoomGroupViewSet,
     basename="room_group_relations",


### PR DESCRIPTION
## Purpose

We want to use api urls in the form `/api/rooms/{room.id}/users/{user.id}/`

## Proposal

- [x] Replace RoomUserViewSet by actions in RoomViewSet.
- [x] Replace RoomGroupViewSet by actions in RoomViewSet.

