### PR TITLE
🚚(backend) rename Room relation to access

### DIFF
--- a/src/magnify/apps/core/factories.py
+++ b/src/magnify/apps/core/factories.py
@@ -152,7 +152,7 @@ class MeetingFactory(factory.django.DjangoModelFactory):
 
 
 class MeetingUserFactory(factory.django.DjangoModelFactory):
-    """Create fake meeting user relations for testing."""
+    """Create fake meeting user accesses for testing."""
 
     class Meta:
         model = core_models.MeetingUser
@@ -163,7 +163,7 @@ class MeetingUserFactory(factory.django.DjangoModelFactory):
 
 
 class MeetingGroupFactory(factory.django.DjangoModelFactory):
-    """Create fake meeting group relations for testing."""
+    """Create fake meeting group accesses for testing."""
 
     class Meta:
         model = core_models.MeetingGroup
@@ -188,13 +188,13 @@ class RoomFactory(factory.django.DjangoModelFactory):
         if create and extracted:
             for item in extracted:
                 if isinstance(item, core_models.User):
-                    core_models.RoomUser.objects.create(
+                    core_models.RoomUserAccess.objects.create(
                         user=item,
                         room=self,
                         is_administrator=random.choice([True, False]),  # nosec
                     )
                 else:
-                    core_models.RoomUser.objects.create(
+                    core_models.RoomUserAccess.objects.create(
                         user=item[0], room=self, is_administrator=item[1]
                     )
 
@@ -204,13 +204,13 @@ class RoomFactory(factory.django.DjangoModelFactory):
         if create and extracted:
             for item in extracted:
                 if isinstance(item, core_models.Group):
-                    core_models.RoomGroup.objects.create(
+                    core_models.RoomGroupAccess.objects.create(
                         group=item,
                         room=self,
                         is_administrator=random.choice([True, False]),  # nosec
                     )
                 else:
-                    core_models.RoomGroup.objects.create(
+                    core_models.RoomGroupAccess.objects.create(
                         group=item[0], room=self, is_administrator=item[1]
                     )
 
@@ -221,22 +221,22 @@ class RoomFactory(factory.django.DjangoModelFactory):
             self.labels.set(extracted)
 
 
-class RoomUserFactory(factory.django.DjangoModelFactory):
-    """Create fake room user relations for testing."""
+class RoomUserAccessFactory(factory.django.DjangoModelFactory):
+    """Create fake room user accesses for testing."""
 
     class Meta:
-        model = core_models.RoomUser
+        model = core_models.RoomUserAccess
 
     room = factory.SubFactory(RoomFactory)
     user = factory.SubFactory(UserFactory)
     is_administrator = factory.Faker("boolean", chance_of_getting_true=25)
 
 
-class RoomGroupFactory(factory.django.DjangoModelFactory):
-    """Create fake room group relations for testing."""
+class RoomGroupAccessFactory(factory.django.DjangoModelFactory):
+    """Create fake room group accesses for testing."""
 
     class Meta:
-        model = core_models.RoomGroup
+        model = core_models.RoomGroupAccess
 
     room = factory.SubFactory(RoomFactory)
     group = factory.SubFactory(GroupFactory)

--- a/src/magnify/apps/core/migrations/0001_initial.py
+++ b/src/magnify/apps/core/migrations/0001_initial.py
@@ -219,7 +219,7 @@ class Migration(migrations.Migration):
             },
         ),
         migrations.CreateModel(
-            name="RoomUser",
+            name="RoomUserAccess",
             fields=[
                 (
                     "id",
@@ -237,7 +237,7 @@ class Migration(migrations.Migration):
                     "room",
                     models.ForeignKey(
                         on_delete=django.db.models.deletion.CASCADE,
-                        related_name="user_relations",
+                        related_name="user_accesses",
                         to="core.room",
                     ),
                 ),
@@ -245,20 +245,20 @@ class Migration(migrations.Migration):
                     "user",
                     models.ForeignKey(
                         on_delete=django.db.models.deletion.CASCADE,
-                        related_name="room_relations",
+                        related_name="room_accesses",
                         to=settings.AUTH_USER_MODEL,
                     ),
                 ),
             ],
             options={
-                "verbose_name": "Room user relation",
-                "verbose_name_plural": "Room user relations",
-                "db_table": "magnify_room_user",
+                "verbose_name": "Room user access",
+                "verbose_name_plural": "Room user accesses",
+                "db_table": "magnify_room_user_access",
                 "unique_together": {("user", "room")},
             },
         ),
         migrations.CreateModel(
-            name="RoomGroup",
+            name="RoomGroupAccess",
             fields=[
                 (
                     "id",
@@ -276,7 +276,7 @@ class Migration(migrations.Migration):
                     "group",
                     models.ForeignKey(
                         on_delete=django.db.models.deletion.CASCADE,
-                        related_name="room_relations",
+                        related_name="room_accesses",
                         to="core.group",
                     ),
                 ),
@@ -284,15 +284,15 @@ class Migration(migrations.Migration):
                     "room",
                     models.ForeignKey(
                         on_delete=django.db.models.deletion.CASCADE,
-                        related_name="group_relations",
+                        related_name="group_accesses",
                         to="core.room",
                     ),
                 ),
             ],
             options={
-                "verbose_name": "Room group relation",
-                "verbose_name_plural": "Room group relations",
-                "db_table": "magnify_room_group",
+                "verbose_name": "Room group access",
+                "verbose_name_plural": "Room group accesses",
+                "db_table": "magnify_room_group_access",
                 "unique_together": {("group", "room")},
             },
         ),
@@ -302,7 +302,7 @@ class Migration(migrations.Migration):
             field=models.ManyToManyField(
                 blank=True,
                 related_name="rooms",
-                through="core.RoomGroup",
+                through="core.RoomGroupAccess",
                 to="core.group",
             ),
         ),
@@ -318,7 +318,7 @@ class Migration(migrations.Migration):
             name="users",
             field=models.ManyToManyField(
                 related_name="rooms",
-                through="core.RoomUser",
+                through="core.RoomUserAccess",
                 to=settings.AUTH_USER_MODEL,
             ),
         ),
@@ -341,7 +341,7 @@ class Migration(migrations.Migration):
                     "group",
                     models.ForeignKey(
                         on_delete=django.db.models.deletion.CASCADE,
-                        related_name="user_relations",
+                        related_name="user_accesses",
                         to="core.group",
                     ),
                 ),
@@ -349,7 +349,7 @@ class Migration(migrations.Migration):
                     "user",
                     models.ForeignKey(
                         on_delete=django.db.models.deletion.CASCADE,
-                        related_name="group_relations",
+                        related_name="group_accesses",
                         to=settings.AUTH_USER_MODEL,
                     ),
                 ),
@@ -379,7 +379,7 @@ class Migration(migrations.Migration):
                     "meeting",
                     models.ForeignKey(
                         on_delete=django.db.models.deletion.CASCADE,
-                        related_name="user_relations",
+                        related_name="user_accesses",
                         to="core.meeting",
                     ),
                 ),
@@ -387,14 +387,14 @@ class Migration(migrations.Migration):
                     "user",
                     models.ForeignKey(
                         on_delete=django.db.models.deletion.CASCADE,
-                        related_name="meeting_relations",
+                        related_name="meeting_accesses",
                         to=settings.AUTH_USER_MODEL,
                     ),
                 ),
             ],
             options={
-                "verbose_name": "Meeting user relation",
-                "verbose_name_plural": "Meeting user relations",
+                "verbose_name": "Meeting user access",
+                "verbose_name_plural": "Meeting user accesses",
                 "db_table": "magnify_meeting_user",
                 "unique_together": {("user", "meeting")},
             },
@@ -418,7 +418,7 @@ class Migration(migrations.Migration):
                     "group",
                     models.ForeignKey(
                         on_delete=django.db.models.deletion.CASCADE,
-                        related_name="meeting_relations",
+                        related_name="meeting_accesses",
                         to="core.group",
                     ),
                 ),
@@ -426,14 +426,14 @@ class Migration(migrations.Migration):
                     "meeting",
                     models.ForeignKey(
                         on_delete=django.db.models.deletion.CASCADE,
-                        related_name="group_relations",
+                        related_name="group_accesses",
                         to="core.meeting",
                     ),
                 ),
             ],
             options={
-                "verbose_name": "Meeting group relation",
-                "verbose_name_plural": "Meeting group relations",
+                "verbose_name": "Meeting group access",
+                "verbose_name_plural": "Meeting group accesses",
                 "db_table": "magnify_meeting_group",
                 "unique_together": {("group", "meeting")},
             },

--- a/src/magnify/apps/core/models.py
+++ b/src/magnify/apps/core/models.py
@@ -152,10 +152,10 @@ class Membership(BaseModel):
     """Link table between users and groups"""
 
     user = models.ForeignKey(
-        User, on_delete=models.CASCADE, related_name="group_relations"
+        User, on_delete=models.CASCADE, related_name="group_accesses"
     )
     group = models.ForeignKey(
-        Group, on_delete=models.CASCADE, related_name="user_relations"
+        Group, on_delete=models.CASCADE, related_name="user_accesses"
     )
     is_administrator = models.BooleanField(default=False)
 
@@ -216,18 +216,18 @@ class MeetingUser(BaseModel):
     user = models.ForeignKey(
         User,
         on_delete=models.CASCADE,
-        related_name="meeting_relations",
+        related_name="meeting_accesses",
     )
     meeting = models.ForeignKey(
-        Meeting, on_delete=models.CASCADE, related_name="user_relations"
+        Meeting, on_delete=models.CASCADE, related_name="user_accesses"
     )
     is_administrator = models.BooleanField(default=False)
 
     class Meta:
         db_table = "magnify_meeting_user"
         unique_together = ("user", "meeting")
-        verbose_name = _("Meeting user relation")
-        verbose_name_plural = _("Meeting user relations")
+        verbose_name = _("Meeting user access")
+        verbose_name_plural = _("Meeting user accesses")
 
     def __str__(self):
         admin_status = " (admin)" if self.is_administrator else ""
@@ -238,18 +238,18 @@ class MeetingGroup(BaseModel):
     """Link table between meetings and groups"""
 
     group = models.ForeignKey(
-        Group, on_delete=models.CASCADE, related_name="meeting_relations"
+        Group, on_delete=models.CASCADE, related_name="meeting_accesses"
     )
     meeting = models.ForeignKey(
-        Meeting, on_delete=models.CASCADE, related_name="group_relations"
+        Meeting, on_delete=models.CASCADE, related_name="group_accesses"
     )
     is_administrator = models.BooleanField(default=False)
 
     class Meta:
         db_table = "magnify_meeting_group"
         unique_together = ("group", "meeting")
-        verbose_name = _("Meeting group relation")
-        verbose_name_plural = _("Meeting group relations")
+        verbose_name = _("Meeting group access")
+        verbose_name_plural = _("Meeting group accesses")
 
     def __str__(self):
         admin_status = " (admin)" if self.is_administrator else ""
@@ -264,9 +264,9 @@ class Room(BaseModel):
 
     is_public = models.BooleanField(default=True)
 
-    users = models.ManyToManyField(User, through="RoomUser", related_name="rooms")
+    users = models.ManyToManyField(User, through="RoomUserAccess", related_name="rooms")
     groups = models.ManyToManyField(
-        Group, through="RoomGroup", blank=True, related_name="rooms"
+        Group, through="RoomGroupAccess", blank=True, related_name="rooms"
     )
     labels = models.ManyToManyField(Label, blank=True, related_name="is_room_label_of")
 
@@ -290,53 +290,53 @@ class Room(BaseModel):
             return False
 
         return (
-            self.user_relations.filter(is_administrator=True, user=user).exists()
-            or self.group_relations.filter(
-                is_administrator=True, group__user_relations__user=user
+            self.user_accesses.filter(is_administrator=True, user=user).exists()
+            or self.group_accesses.filter(
+                is_administrator=True, group__user_accesses__user=user
             ).exists()
         )
 
 
-class RoomUser(BaseModel):
+class RoomUserAccess(BaseModel):
     """Link table between rooms and users"""
 
     user = models.ForeignKey(
         User,
         on_delete=models.CASCADE,
-        related_name="room_relations",
+        related_name="room_accesses",
     )
     room = models.ForeignKey(
-        Room, on_delete=models.CASCADE, related_name="user_relations"
+        Room, on_delete=models.CASCADE, related_name="user_accesses"
     )
     is_administrator = models.BooleanField(default=False)
 
     class Meta:
-        db_table = "magnify_room_user"
+        db_table = "magnify_room_user_access"
         unique_together = ("user", "room")
-        verbose_name = _("Room user relation")
-        verbose_name_plural = _("Room user relations")
+        verbose_name = _("Room user access")
+        verbose_name_plural = _("Room user accesses")
 
     def __str__(self):
         admin_status = " (admin)" if self.is_administrator else ""
         return f"{capfirst(self.room.name):s} / {capfirst(self.user.name):s}{admin_status:s}"
 
 
-class RoomGroup(BaseModel):
+class RoomGroupAccess(BaseModel):
     """Link table between rooms and groups"""
 
     group = models.ForeignKey(
-        Group, on_delete=models.CASCADE, related_name="room_relations"
+        Group, on_delete=models.CASCADE, related_name="room_accesses"
     )
     room = models.ForeignKey(
-        Room, on_delete=models.CASCADE, related_name="group_relations"
+        Room, on_delete=models.CASCADE, related_name="group_accesses"
     )
     is_administrator = models.BooleanField(default=False)
 
     class Meta:
-        db_table = "magnify_room_group"
+        db_table = "magnify_room_group_access"
         unique_together = ("group", "room")
-        verbose_name = _("Room group relation")
-        verbose_name_plural = _("Room group relations")
+        verbose_name = _("Room group access")
+        verbose_name_plural = _("Room group accesses")
 
     def __str__(self):
         admin_status = " (admin)" if self.is_administrator else ""

--- a/src/magnify/apps/core/permissions.py
+++ b/src/magnify/apps/core/permissions.py
@@ -50,10 +50,10 @@ class IsObjectAdministrator(permissions.BasePermission):
                 condition |= Q(users=user) | Q(groups__members=user)
             return obj._meta.model.objects.filter(Q(id=obj.id) & condition).exists()
 
-        return obj.user_relations.filter(
+        return obj.user_accesses.filter(
             is_administrator=True, user=user
-        ) or obj.group_relations.filter(
-            is_administrator=True, group__user_relations__user=user
+        ) or obj.group_accesses.filter(
+            is_administrator=True, group__user_accesses__user=user
         )
 
 
@@ -70,8 +70,8 @@ class IsRoomAdministrator(permissions.BasePermission):
         """Check that the logged-in user is adminisrator of the linked room."""
         user = request.user
         return user.is_authenticated and (
-            obj.user_relations.filter(is_administrator=True, user=user)
-            or obj.group_relations.filter(
-                is_administrator=True, group__user_relations__user=user
+            obj.user_accesses.filter(is_administrator=True, user=user)
+            or obj.group_accesses.filter(
+                is_administrator=True, group__user_accesses__user=user
             )
         )

--- a/src/magnify/apps/core/serializers/__init__.py
+++ b/src/magnify/apps/core/serializers/__init__.py
@@ -1,6 +1,6 @@
 """Magnify core serializers"""
 
-from .rooms import RoomGroupSerializer, RoomSerializer, RoomUserSerializer
+from .rooms import RoomGroupAccessSerializer, RoomSerializer, RoomUserAccessSerializer
 from .users import PasswordChangeSerializer, RegistrationSerializer, UserSerializer
 
 # Necessary precision to comply with PEP8
@@ -8,7 +8,7 @@ __all__ = [
     "PasswordChangeSerializer",
     "RegistrationSerializer",
     "RoomSerializer",
-    "RoomGroupSerializer",
-    "RoomUserSerializer",
+    "RoomGroupAccessSerializer",
+    "RoomUserAccessSerializer",
     "UserSerializer",
 ]

--- a/tests/apps/core/test_core_api_room_group_relations.py
+++ b/tests/apps/core/test_core_api_room_group_relations.py
@@ -1,5 +1,5 @@
 """
-Tests for RoomGroups API endpoints in Magnify's core app.
+Tests for RoomGroupAccessAccesses API endpoints in Magnify's core app.
 """
 import random
 
@@ -9,28 +9,28 @@ from rest_framework_simplejwt.tokens import AccessToken
 from magnify.apps.core.factories import (
     GroupFactory,
     RoomFactory,
-    RoomGroupFactory,
+    RoomGroupAccessFactory,
     UserFactory,
 )
-from magnify.apps.core.models import RoomGroup
+from magnify.apps.core.models import RoomGroupAccess
 
 
-class RoomGroupsApiTestCase(APITestCase):
-    """Test requests on magnify's core app RoomGroup API endpoint."""
+class RoomGroupAccessAccessesApiTestCase(APITestCase):
+    """Test requests on magnify's core app RoomGroupAccess API endpoint."""
 
-    def test_api_room_group_relations_list_anonymous(self):
-        """Anonymous users should not be allowed to list room group relations."""
-        relation = RoomGroupFactory()
+    def test_api_room_group_accesses_list_anonymous(self):
+        """Anonymous users should not be allowed to list room group accesses."""
+        access = RoomGroupAccessFactory()
 
-        response = self.client.get(f"/api/rooms/{relation.room.id!s}/groups/")
+        response = self.client.get(f"/api/rooms/{access.room.id!s}/groups/")
         self.assertEqual(response.status_code, 401)
         self.assertEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
 
-    def test_api_room_group_relations_list_authenticated(self):
+    def test_api_room_group_accesses_list_authenticated(self):
         """
-        Authenticated users should not be allowed to list room group relations.
+        Authenticated users should not be allowed to list room group accesses.
         """
         user = UserFactory()
         group = GroupFactory(members=[user])
@@ -39,29 +39,29 @@ class RoomGroupsApiTestCase(APITestCase):
         other_user = UserFactory()
         other_group = GroupFactory(members=[other_user])
 
-        for relation in [
-            RoomGroupFactory(room__is_public=False),
-            RoomGroupFactory(room__is_public=True),
-            RoomGroupFactory(room__is_public=False, room__groups=[group]),
-            RoomGroupFactory(room__is_public=False, room__users=[user]),
-            RoomGroupFactory(room__is_public=False, room__groups=[other_group]),
-            RoomGroupFactory(room__is_public=False, room__users=[other_user]),
+        for access in [
+            RoomGroupAccessFactory(room__is_public=False),
+            RoomGroupAccessFactory(room__is_public=True),
+            RoomGroupAccessFactory(room__is_public=False, room__groups=[group]),
+            RoomGroupAccessFactory(room__is_public=False, room__users=[user]),
+            RoomGroupAccessFactory(room__is_public=False, room__groups=[other_group]),
+            RoomGroupAccessFactory(room__is_public=False, room__users=[other_user]),
         ]:
             response = self.client.get(
-                f"/api/rooms/{relation.room.id!s}/groups/",
+                f"/api/rooms/{access.room.id!s}/groups/",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
 
             self.assertEqual(response.status_code, 405)
             self.assertEqual(response.json(), {"detail": 'Method "GET" not allowed.'})
 
-    def test_api_room_group_relations_retrieve_anonymous(self):
+    def test_api_room_group_accesses_retrieve_anonymous(self):
         """
-        Anonymous users should not be allowed to retrieve a room group relation.
+        Anonymous users should not be allowed to retrieve a room group access.
         """
-        relation = RoomGroupFactory()
+        access = RoomGroupAccessFactory()
         response = self.client.get(
-            f"/api/rooms/{relation.room.id!s}/groups/{relation.group.id!s}/",
+            f"/api/rooms/{access.room.id!s}/groups/{access.group.id!s}/",
         )
 
         self.assertEqual(response.status_code, 401)
@@ -69,17 +69,17 @@ class RoomGroupsApiTestCase(APITestCase):
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
 
-    def test_api_room_group_relations_retrieve_authenticated(self):
+    def test_api_room_group_accesses_retrieve_authenticated(self):
         """
-        Authenticated users should not be allowed to retrieve a room group relation
+        Authenticated users should not be allowed to retrieve a room group access
         """
-        relation = RoomGroupFactory()
+        access = RoomGroupAccessFactory()
 
         user = UserFactory()
         jwt_token = AccessToken.for_user(user)
 
         response = self.client.get(
-            f"/api/rooms/{relation.room.id!s}/groups/{relation.group.id!s}/",
+            f"/api/rooms/{access.room.id!s}/groups/{access.group.id!s}/",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 403)
@@ -89,19 +89,19 @@ class RoomGroupsApiTestCase(APITestCase):
             {"detail": "You do not have permission to perform this action."},
         )
 
-    def test_api_room_group_relations_retrieve_administrator_direct(self):
+    def test_api_room_group_accesses_retrieve_administrator_direct(self):
         """
         A user who is a direct administrator of a room should be allowed to retrieve the
-        associated room group relations
+        associated room group accesses
         """
         user = UserFactory()
-        relation = RoomGroupFactory(room__users=[(user, True)])
+        access = RoomGroupAccessFactory(room__users=[(user, True)])
 
         jwt_token = AccessToken.for_user(user)
 
         with self.assertNumQueries(4):
             response = self.client.get(
-                f"/api/rooms/{relation.room.id!s}/groups/{relation.group.id!s}/",
+                f"/api/rooms/{access.room.id!s}/groups/{access.group.id!s}/",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
         self.assertEqual(response.status_code, 200)
@@ -109,26 +109,26 @@ class RoomGroupsApiTestCase(APITestCase):
         self.assertEqual(
             response.json(),
             {
-                "id": str(relation.id),
-                "group": str(relation.group.id),
-                "room": str(relation.room.id),
-                "is_administrator": relation.is_administrator,
+                "id": str(access.id),
+                "group": str(access.group.id),
+                "room": str(access.room.id),
+                "is_administrator": access.is_administrator,
             },
         )
 
-    def test_api_room_group_relations_retrieve_administrator_via_group(self):
+    def test_api_room_group_accesses_retrieve_administrator_via_group(self):
         """
         A user who is administrator of a room via a group should be allowed to see related users
         and groups.
         """
         administrator = UserFactory()
         group = GroupFactory(members=[administrator])
-        relation = RoomGroupFactory(room__groups=[(group, True)])
+        access = RoomGroupAccessFactory(room__groups=[(group, True)])
 
         jwt_token = AccessToken.for_user(administrator)
 
         response = self.client.get(
-            f"/api/rooms/{relation.room.id!s}/groups/{relation.group.id!s}/",
+            f"/api/rooms/{access.room.id!s}/groups/{access.group.id!s}/",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 200)
@@ -136,15 +136,15 @@ class RoomGroupsApiTestCase(APITestCase):
         self.assertEqual(
             response.json(),
             {
-                "id": str(relation.id),
-                "group": str(relation.group.id),
-                "room": str(relation.room.id),
-                "is_administrator": relation.is_administrator,
+                "id": str(access.id),
+                "group": str(access.group.id),
+                "room": str(access.room.id),
+                "is_administrator": access.is_administrator,
             },
         )
 
-    def test_api_room_group_relations_create_anonymous(self):
-        """Anonymous users should not be allowed to create room group relations."""
+    def test_api_room_group_accesses_create_anonymous(self):
+        """Anonymous users should not be allowed to create room group accesses."""
         group = GroupFactory()
         room = RoomFactory()
         is_administrator = random.choice([True, False])
@@ -160,10 +160,10 @@ class RoomGroupsApiTestCase(APITestCase):
         self.assertEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
-        self.assertFalse(RoomGroup.objects.exists())
+        self.assertFalse(RoomGroupAccess.objects.exists())
 
-    def test_api_room_group_relations_create_authenticated(self):
-        """Authenticated users should not be allowed to create room group relations."""
+    def test_api_room_group_accesses_create_authenticated(self):
+        """Authenticated users should not be allowed to create room group accesses."""
         user = UserFactory()
         room = RoomFactory()
         group = GroupFactory()
@@ -182,13 +182,13 @@ class RoomGroupsApiTestCase(APITestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.json(),
-            {"room": ["You must be administrator of a room to add relations to it."]},
+            {"room": ["You must be administrator of a room to add accesses to it."]},
         )
-        self.assertFalse(RoomGroup.objects.exists())
+        self.assertFalse(RoomGroupAccess.objects.exists())
 
-    def test_api_room_group_relations_create_administrator_users(self):
+    def test_api_room_group_accesses_create_administrator_users(self):
         """
-        Direct administrators of a room should be allowed to create a room/group relation
+        Direct administrators of a room should be allowed to create a room/group access
         in this room.
         """
         user = UserFactory()
@@ -198,7 +198,7 @@ class RoomGroupsApiTestCase(APITestCase):
 
         jwt_token = AccessToken.for_user(user)
 
-        self.assertFalse(RoomGroup.objects.exists())
+        self.assertFalse(RoomGroupAccess.objects.exists())
         response = self.client.post(
             f"/api/rooms/{room.id!s}/groups/",
             {
@@ -208,13 +208,13 @@ class RoomGroupsApiTestCase(APITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 201)
-        self.assertEqual(RoomGroup.objects.count(), 1)
-        self.assertTrue(RoomGroup.objects.filter(group=group).exists())
+        self.assertEqual(RoomGroupAccess.objects.count(), 1)
+        self.assertTrue(RoomGroupAccess.objects.filter(group=group).exists())
 
-    def test_api_room_group_relations_create_administrator_groups(self):
+    def test_api_room_group_accesses_create_administrator_groups(self):
         """
         Users who are administrators of a room via a group should be allowed to create a room
-        group relation in it."""
+        group access in it."""
         user = UserFactory()
         group = GroupFactory(members=[user])
         room = RoomFactory(groups=[(group, True)])
@@ -223,7 +223,7 @@ class RoomGroupsApiTestCase(APITestCase):
 
         jwt_token = AccessToken.for_user(user)
 
-        self.assertEqual(RoomGroup.objects.count(), 1)
+        self.assertEqual(RoomGroupAccess.objects.count(), 1)
         response = self.client.post(
             f"/api/rooms/{room.id!s}/groups/",
             {
@@ -233,39 +233,39 @@ class RoomGroupsApiTestCase(APITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 201)
-        self.assertEqual(RoomGroup.objects.count(), 2)
-        self.assertTrue(RoomGroup.objects.filter(group=other_group).exists())
+        self.assertEqual(RoomGroupAccess.objects.count(), 2)
+        self.assertTrue(RoomGroupAccess.objects.filter(group=other_group).exists())
 
-    def test_api_room_group_relations_update_authenticated(self):
-        """Authenticated users should not be allowed to update a room group relation."""
+    def test_api_room_group_accesses_update_authenticated(self):
+        """Authenticated users should not be allowed to update a room group access."""
         user = UserFactory()
-        relation = RoomGroupFactory()
-        is_administrator = relation.is_administrator
+        access = RoomGroupAccessFactory()
+        is_administrator = access.is_administrator
         jwt_token = AccessToken.for_user(user)
 
         response = self.client.put(
-            f"/api/rooms/{relation.room.id!s}/groups/{relation.group.id!s}/",
+            f"/api/rooms/{access.room.id!s}/groups/{access.group.id!s}/",
             {
                 "is_administrator": not is_administrator,
             },
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 403)
-        relation.refresh_from_db()
-        self.assertEqual(relation.is_administrator, is_administrator)
+        access.refresh_from_db()
+        self.assertEqual(access.is_administrator, is_administrator)
 
-    def test_api_room_group_relations_update_administrator_users(self):
+    def test_api_room_group_accesses_update_administrator_users(self):
         """
         Direct administrators of a room should be allowed to update its related
-        room group relations.
+        room group accesses.
         """
         user = UserFactory()
-        relation = RoomGroupFactory(room__users=[(user, True)])
-        is_administrator = relation.is_administrator
+        access = RoomGroupAccessFactory(room__users=[(user, True)])
+        is_administrator = access.is_administrator
         jwt_token = AccessToken.for_user(user)
 
         response = self.client.put(
-            f"/api/rooms/{relation.room.id!s}/groups/{relation.group.id!s}/",
+            f"/api/rooms/{access.room.id!s}/groups/{access.group.id!s}/",
             {
                 "is_administrator": not is_administrator,
             },
@@ -273,117 +273,117 @@ class RoomGroupsApiTestCase(APITestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        relation.refresh_from_db()
-        self.assertEqual(relation.is_administrator, not is_administrator)
+        access.refresh_from_db()
+        self.assertEqual(access.is_administrator, not is_administrator)
 
-    def test_api_room_group_relations_update_administrator_groups(self):
+    def test_api_room_group_accesses_update_administrator_groups(self):
         """Users who are administrators of a room via a group should be allowed to update it."""
         user = UserFactory()
         group = GroupFactory(members=[user])
-        relation = RoomGroupFactory(room__groups=[(group, True)])
-        is_administrator = relation.is_administrator
+        access = RoomGroupAccessFactory(room__groups=[(group, True)])
+        is_administrator = access.is_administrator
         jwt_token = AccessToken.for_user(user)
 
         response = self.client.put(
-            f"/api/rooms/{relation.room.id!s}/groups/{relation.group.id!s}/",
+            f"/api/rooms/{access.room.id!s}/groups/{access.group.id!s}/",
             {
                 "is_administrator": not is_administrator,
             },
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 200)
-        relation.refresh_from_db()
-        self.assertEqual(relation.is_administrator, not is_administrator)
+        access.refresh_from_db()
+        self.assertEqual(access.is_administrator, not is_administrator)
 
-    def test_api_room_group_relations_update_administrator_of_another(self):
+    def test_api_room_group_accesses_update_administrator_of_another(self):
         """
         Being administrator of a room should not grant authorization to update another room's
-        room/user relation.
+        room/user access.
         """
         user = UserFactory()
         RoomFactory(users=[(user, True)])
-        relation = RoomGroupFactory()
-        is_administrator = relation.is_administrator
+        access = RoomGroupAccessFactory()
+        is_administrator = access.is_administrator
         jwt_token = AccessToken.for_user(user)
 
         response = self.client.put(
-            f"/api/rooms/{relation.room.id!s}/groups/{relation.group.id!s}/",
+            f"/api/rooms/{access.room.id!s}/groups/{access.group.id!s}/",
             {
                 "is_administrator": not is_administrator,
             },
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 403)
-        relation.refresh_from_db()
-        self.assertEqual(relation.is_administrator, is_administrator)
+        access.refresh_from_db()
+        self.assertEqual(access.is_administrator, is_administrator)
 
-    def test_api_room_group_relations_delete_anonymous(self):
+    def test_api_room_group_accesses_delete_anonymous(self):
         """Anonymous users should not be allowed to destroy a room."""
-        relation = RoomGroupFactory()
+        access = RoomGroupAccessFactory()
 
         response = self.client.delete(
-            f"/api/rooms/{relation.room.id!s}/groups/{relation.group.id!s}/",
+            f"/api/rooms/{access.room.id!s}/groups/{access.group.id!s}/",
         )
 
         self.assertEqual(response.status_code, 401)
-        self.assertEqual(RoomGroup.objects.count(), 1)
+        self.assertEqual(RoomGroupAccess.objects.count(), 1)
 
-    def test_api_room_group_relations_delete_authenticated(self):
+    def test_api_room_group_accesses_delete_authenticated(self):
         """
-        Authenticated users should not be allowed to delete a room group relation for a room in
+        Authenticated users should not be allowed to delete a room group access for a room in
         which they are not administrator.
         """
-        relation = RoomGroupFactory()
+        access = RoomGroupAccessFactory()
         user = UserFactory()
         jwt_token = AccessToken.for_user(user)
 
         response = self.client.delete(
-            f"/api/rooms/{relation.room.id!s}/groups/{relation.group.id!s}/",
+            f"/api/rooms/{access.room.id!s}/groups/{access.group.id!s}/",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(RoomGroup.objects.count(), 1)
+        self.assertEqual(RoomGroupAccess.objects.count(), 1)
 
-    def test_api_room_group_relations_delete_administrator_users(self):
+    def test_api_room_group_accesses_delete_administrator_users(self):
         """
-        Authenticated users should be able to delete a room group relation for a room in which
+        Authenticated users should be able to delete a room group access for a room in which
         they are directly administrator.
         """
         user = UserFactory()
         room = RoomFactory(users=[(user, True)])
-        relation = RoomGroupFactory(room=room)
+        access = RoomGroupAccessFactory(room=room)
 
         jwt_token = AccessToken.for_user(user)
 
-        self.assertEqual(RoomGroup.objects.count(), 1)
-        self.assertTrue(RoomGroup.objects.filter(group=relation.group).exists())
+        self.assertEqual(RoomGroupAccess.objects.count(), 1)
+        self.assertTrue(RoomGroupAccess.objects.filter(group=access.group).exists())
         response = self.client.delete(
-            f"/api/rooms/{relation.room.id!s}/groups/{relation.group.id!s}/",
+            f"/api/rooms/{access.room.id!s}/groups/{access.group.id!s}/",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
         self.assertEqual(response.status_code, 204)
-        self.assertFalse(RoomGroup.objects.filter(group=relation.group).exists())
+        self.assertFalse(RoomGroupAccess.objects.filter(group=access.group).exists())
 
-    def test_api_room_group_relations_delete_administrator_groups(self):
+    def test_api_room_group_accesses_delete_administrator_groups(self):
         """
-        Authenticated users should be able to delete a room group relation for a room in which
+        Authenticated users should be able to delete a room group access for a room in which
         they are administrator via a group.
         """
         user = UserFactory()
         group = GroupFactory(members=[user])
-        relation = RoomGroupFactory(room__groups=[(group, True)])
+        access = RoomGroupAccessFactory(room__groups=[(group, True)])
 
         jwt_token = AccessToken.for_user(user)
 
-        self.assertEqual(RoomGroup.objects.count(), 2)
-        self.assertTrue(RoomGroup.objects.filter(group=relation.group).exists())
+        self.assertEqual(RoomGroupAccess.objects.count(), 2)
+        self.assertTrue(RoomGroupAccess.objects.filter(group=access.group).exists())
         response = self.client.delete(
-            f"/api/rooms/{relation.room.id!s}/groups/{relation.group.id!s}/",
+            f"/api/rooms/{access.room.id!s}/groups/{access.group.id!s}/",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
         self.assertEqual(response.status_code, 204)
-        self.assertEqual(RoomGroup.objects.count(), 1)
-        self.assertFalse(RoomGroup.objects.filter(group=relation.group).exists())
+        self.assertEqual(RoomGroupAccess.objects.count(), 1)
+        self.assertFalse(RoomGroupAccess.objects.filter(group=access.group).exists())

--- a/tests/apps/core/test_core_api_room_user_relations.py
+++ b/tests/apps/core/test_core_api_room_user_relations.py
@@ -1,5 +1,5 @@
 """
-Tests for RoomUsers API endpoints in Magnify's core app.
+Tests for RoomUserAccesses API endpoints in Magnify's core app.
 """
 import random
 
@@ -9,28 +9,28 @@ from rest_framework_simplejwt.tokens import AccessToken
 from magnify.apps.core.factories import (
     GroupFactory,
     RoomFactory,
-    RoomUserFactory,
+    RoomUserAccessFactory,
     UserFactory,
 )
-from magnify.apps.core.models import RoomUser
+from magnify.apps.core.models import RoomUserAccess
 
 
-class RoomUsersApiTestCase(APITestCase):
-    """Test requests on magnify's core app RoomUser API endpoint."""
+class RoomUserAccessesApiTestCase(APITestCase):
+    """Test requests on magnify's core app RoomUserAccess API endpoint."""
 
-    def test_api_room_user_relations_list_anonymous(self):
-        """Anonymous users should not be allowed to list room user relations."""
-        relation = RoomUserFactory()
+    def test_api_room_user_accesses_list_anonymous(self):
+        """Anonymous users should not be allowed to list room user accesses."""
+        access = RoomUserAccessFactory()
 
-        response = self.client.get(f"/api/rooms/{relation.room.id!s}/users/")
+        response = self.client.get(f"/api/rooms/{access.room.id!s}/users/")
         self.assertEqual(response.status_code, 401)
         self.assertEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
 
-    def test_api_room_user_relations_list_authenticated(self):
+    def test_api_room_user_accesses_list_authenticated(self):
         """
-        Authenticated users should not be allowed to list room user relations.
+        Authenticated users should not be allowed to list room user accesses.
         """
         user = UserFactory()
         group = GroupFactory(members=[user])
@@ -39,28 +39,28 @@ class RoomUsersApiTestCase(APITestCase):
         other_user = UserFactory()
         other_group = GroupFactory(members=[other_user])
 
-        for relation in [
-            RoomUserFactory(room__is_public=False),
-            RoomUserFactory(room__is_public=True),
-            RoomUserFactory(room__is_public=False, room__groups=[group]),
-            RoomUserFactory(room__is_public=False, room__users=[user]),
-            RoomUserFactory(room__is_public=False, room__groups=[other_group]),
-            RoomUserFactory(room__is_public=False, room__users=[other_user]),
+        for access in [
+            RoomUserAccessFactory(room__is_public=False),
+            RoomUserAccessFactory(room__is_public=True),
+            RoomUserAccessFactory(room__is_public=False, room__groups=[group]),
+            RoomUserAccessFactory(room__is_public=False, room__users=[user]),
+            RoomUserAccessFactory(room__is_public=False, room__groups=[other_group]),
+            RoomUserAccessFactory(room__is_public=False, room__users=[other_user]),
         ]:
             response = self.client.get(
-                f"/api/rooms/{relation.room.id!s}/users/",
+                f"/api/rooms/{access.room.id!s}/users/",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
             self.assertEqual(response.status_code, 405)
             self.assertEqual(response.json(), {"detail": 'Method "GET" not allowed.'})
 
-    def test_api_room_user_relations_retrieve_anonymous(self):
+    def test_api_room_user_accesses_retrieve_anonymous(self):
         """
-        Anonymous users should not be allowed to retrieve a room user relation.
+        Anonymous users should not be allowed to retrieve a room user access.
         """
-        relation = RoomUserFactory()
+        access = RoomUserAccessFactory()
         response = self.client.get(
-            f"/api/rooms/{relation.room.id!s}/users/{relation.user.id!s}/",
+            f"/api/rooms/{access.room.id!s}/users/{access.user.id!s}/",
         )
 
         self.assertEqual(response.status_code, 401)
@@ -68,17 +68,17 @@ class RoomUsersApiTestCase(APITestCase):
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
 
-    def test_api_room_user_relations_retrieve_authenticated(self):
+    def test_api_room_user_accesses_retrieve_authenticated(self):
         """
-        Authenticated users should not be allowed to retrieve a room user relation
+        Authenticated users should not be allowed to retrieve a room user access
         """
-        relation = RoomUserFactory()
+        access = RoomUserAccessFactory()
 
         user = UserFactory()
         jwt_token = AccessToken.for_user(user)
 
         response = self.client.get(
-            f"/api/rooms/{relation.room.id!s}/users/{relation.user.id!s}/",
+            f"/api/rooms/{access.room.id!s}/users/{access.user.id!s}/",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 403)
@@ -88,19 +88,19 @@ class RoomUsersApiTestCase(APITestCase):
             {"detail": "You do not have permission to perform this action."},
         )
 
-    def test_api_room_user_relations_retrieve_administrator_direct(self):
+    def test_api_room_user_accesses_retrieve_administrator_direct(self):
         """
         A user who is a direct administrator of a room should be allowed to retrieve the
-        associated room user relations
+        associated room user accesses
         """
         user = UserFactory()
-        relation = RoomUserFactory(room__users=[(user, True)])
+        access = RoomUserAccessFactory(room__users=[(user, True)])
 
         jwt_token = AccessToken.for_user(user)
 
         with self.assertNumQueries(4):
             response = self.client.get(
-                f"/api/rooms/{relation.room.id!s}/users/{relation.user.id!s}/",
+                f"/api/rooms/{access.room.id!s}/users/{access.user.id!s}/",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
         self.assertEqual(response.status_code, 200)
@@ -108,26 +108,26 @@ class RoomUsersApiTestCase(APITestCase):
         self.assertEqual(
             response.json(),
             {
-                "id": str(relation.id),
-                "user": str(relation.user.id),
-                "room": str(relation.room.id),
-                "is_administrator": relation.is_administrator,
+                "id": str(access.id),
+                "user": str(access.user.id),
+                "room": str(access.room.id),
+                "is_administrator": access.is_administrator,
             },
         )
 
-    def test_api_room_user_relations_retrieve_administrator_via_group(self):
+    def test_api_room_user_accesses_retrieve_administrator_via_group(self):
         """
         A user who is administrator of a room via a group should be allowed to see related users
         and groups.
         """
         administrator = UserFactory()
         group = GroupFactory(members=[administrator])
-        relation = RoomUserFactory(room__groups=[(group, True)])
+        access = RoomUserAccessFactory(room__groups=[(group, True)])
 
         jwt_token = AccessToken.for_user(administrator)
 
         response = self.client.get(
-            f"/api/rooms/{relation.room.id!s}/users/{relation.user.id!s}/",
+            f"/api/rooms/{access.room.id!s}/users/{access.user.id!s}/",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 200)
@@ -135,15 +135,15 @@ class RoomUsersApiTestCase(APITestCase):
         self.assertEqual(
             response.json(),
             {
-                "id": str(relation.id),
-                "user": str(relation.user.id),
-                "room": str(relation.room.id),
-                "is_administrator": relation.is_administrator,
+                "id": str(access.id),
+                "user": str(access.user.id),
+                "room": str(access.room.id),
+                "is_administrator": access.is_administrator,
             },
         )
 
-    def test_api_room_user_relations_create_anonymous(self):
-        """Anonymous users should not be allowed to create room user relations."""
+    def test_api_room_user_accesses_create_anonymous(self):
+        """Anonymous users should not be allowed to create room user accesses."""
         user = UserFactory()
         room = RoomFactory()
         is_administrator = random.choice([True, False])
@@ -159,10 +159,10 @@ class RoomUsersApiTestCase(APITestCase):
         self.assertEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
-        self.assertFalse(RoomUser.objects.exists())
+        self.assertFalse(RoomUserAccess.objects.exists())
 
-    def test_api_room_user_relations_create_authenticated(self):
-        """Authenticated users should not be allowed to create room user relations."""
+    def test_api_room_user_accesses_create_authenticated(self):
+        """Authenticated users should not be allowed to create room user accesses."""
         user = UserFactory()
         room = RoomFactory()
         other_user = UserFactory()
@@ -181,13 +181,13 @@ class RoomUsersApiTestCase(APITestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.json(),
-            {"room": ["You must be administrator of a room to add relations to it."]},
+            {"room": ["You must be administrator of a room to add accesses to it."]},
         )
-        self.assertFalse(RoomUser.objects.exists())
+        self.assertFalse(RoomUserAccess.objects.exists())
 
-    def test_api_room_user_relations_create_administrator_users(self):
+    def test_api_room_user_accesses_create_administrator_users(self):
         """
-        Direct administrators of a room should be allowed to create a room/user relation
+        Direct administrators of a room should be allowed to create a room/user access
         in this room.
         """
         user = UserFactory()
@@ -207,13 +207,13 @@ class RoomUsersApiTestCase(APITestCase):
         )
 
         self.assertEqual(response.status_code, 201)
-        self.assertEqual(RoomUser.objects.count(), 2)
-        self.assertTrue(RoomUser.objects.filter(user=other_user).exists())
+        self.assertEqual(RoomUserAccess.objects.count(), 2)
+        self.assertTrue(RoomUserAccess.objects.filter(user=other_user).exists())
 
-    def test_api_room_user_relations_create_administrator_groups(self):
+    def test_api_room_user_accesses_create_administrator_groups(self):
         """
         Users who are administrators of a room via a group should be allowed to create a room
-        user relation in it."""
+        user access in it."""
         user = UserFactory()
         group = GroupFactory(members=[user])
         room = RoomFactory(groups=[(group, True)])
@@ -222,7 +222,7 @@ class RoomUsersApiTestCase(APITestCase):
 
         jwt_token = AccessToken.for_user(user)
 
-        self.assertFalse(RoomUser.objects.exists())
+        self.assertFalse(RoomUserAccess.objects.exists())
         response = self.client.post(
             f"/api/rooms/{room.id!s}/users/",
             {
@@ -232,39 +232,39 @@ class RoomUsersApiTestCase(APITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 201)
-        self.assertEqual(RoomUser.objects.count(), 1)
-        self.assertTrue(RoomUser.objects.filter(user=other_user).exists())
+        self.assertEqual(RoomUserAccess.objects.count(), 1)
+        self.assertTrue(RoomUserAccess.objects.filter(user=other_user).exists())
 
-    def test_api_room_user_relations_update_authenticated(self):
-        """Authenticated users should not be allowed to update a room user relation."""
+    def test_api_room_user_accesses_update_authenticated(self):
+        """Authenticated users should not be allowed to update a room user access."""
         user = UserFactory()
-        relation = RoomUserFactory()
-        is_administrator = relation.is_administrator
+        access = RoomUserAccessFactory()
+        is_administrator = access.is_administrator
         jwt_token = AccessToken.for_user(user)
 
         response = self.client.put(
-            f"/api/rooms/{relation.room.id!s}/users/{relation.user.id!s}/",
+            f"/api/rooms/{access.room.id!s}/users/{access.user.id!s}/",
             {
                 "is_administrator": not is_administrator,
             },
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 403)
-        relation.refresh_from_db()
-        self.assertEqual(relation.is_administrator, is_administrator)
+        access.refresh_from_db()
+        self.assertEqual(access.is_administrator, is_administrator)
 
-    def test_api_room_user_relations_update_administrator_users(self):
+    def test_api_room_user_accesses_update_administrator_users(self):
         """
         Direct administrators of a room should be allowed to update its related
-        room user relations.
+        room user accesses.
         """
         user = UserFactory()
-        relation = RoomUserFactory(room__users=[(user, True)])
-        is_administrator = relation.is_administrator
+        access = RoomUserAccessFactory(room__users=[(user, True)])
+        is_administrator = access.is_administrator
         jwt_token = AccessToken.for_user(user)
 
         response = self.client.put(
-            f"/api/rooms/{relation.room.id!s}/users/{relation.user.id!s}/",
+            f"/api/rooms/{access.room.id!s}/users/{access.user.id!s}/",
             {
                 "is_administrator": not is_administrator,
             },
@@ -272,114 +272,114 @@ class RoomUsersApiTestCase(APITestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        relation.refresh_from_db()
-        self.assertEqual(relation.is_administrator, not is_administrator)
+        access.refresh_from_db()
+        self.assertEqual(access.is_administrator, not is_administrator)
 
-    def test_api_room_user_relations_update_administrator_groups(self):
+    def test_api_room_user_accesses_update_administrator_groups(self):
         """Users who are administrators of a room via a group should be allowed to update it."""
         user = UserFactory()
         group = GroupFactory(members=[user])
-        relation = RoomUserFactory(room__groups=[(group, True)])
-        is_administrator = relation.is_administrator
+        access = RoomUserAccessFactory(room__groups=[(group, True)])
+        is_administrator = access.is_administrator
         jwt_token = AccessToken.for_user(user)
 
         response = self.client.put(
-            f"/api/rooms/{relation.room.id!s}/users/{relation.user.id!s}/",
+            f"/api/rooms/{access.room.id!s}/users/{access.user.id!s}/",
             {
                 "is_administrator": not is_administrator,
             },
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 200)
-        relation.refresh_from_db()
-        self.assertEqual(relation.is_administrator, not is_administrator)
+        access.refresh_from_db()
+        self.assertEqual(access.is_administrator, not is_administrator)
 
-    def test_api_room_user_relations_update_administrator_of_another(self):
+    def test_api_room_user_accesses_update_administrator_of_another(self):
         """
         Being administrator of a room should not grant authorization to update another room's
-        room/user relation.
+        room/user access.
         """
         user = UserFactory()
         RoomFactory(users=[(user, True)])
-        relation = RoomUserFactory()
-        is_administrator = relation.is_administrator
+        access = RoomUserAccessFactory()
+        is_administrator = access.is_administrator
         jwt_token = AccessToken.for_user(user)
 
         response = self.client.put(
-            f"/api/rooms/{relation.room.id!s}/users/{relation.user.id!s}/",
+            f"/api/rooms/{access.room.id!s}/users/{access.user.id!s}/",
             {
                 "is_administrator": not is_administrator,
             },
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
         self.assertEqual(response.status_code, 403)
-        relation.refresh_from_db()
-        self.assertEqual(relation.is_administrator, is_administrator)
+        access.refresh_from_db()
+        self.assertEqual(access.is_administrator, is_administrator)
 
-    def test_api_room_user_relations_delete_anonymous(self):
+    def test_api_room_user_accesss_delete_anonymous(self):
         """Anonymous users should not be allowed to destroy a room."""
-        relation = RoomUserFactory()
+        access = RoomUserAccessFactory()
 
         response = self.client.delete(
-            f"/api/rooms/{relation.room.id!s}/users/{relation.user.id!s}/",
+            f"/api/rooms/{access.room.id!s}/users/{access.user.id!s}/",
         )
 
         self.assertEqual(response.status_code, 401)
-        self.assertEqual(RoomUser.objects.count(), 1)
+        self.assertEqual(RoomUserAccess.objects.count(), 1)
 
-    def test_api_room_user_relations_delete_authenticated(self):
+    def test_api_room_user_accesss_delete_authenticated(self):
         """
-        Authenticated users should not be allowed to delete a room user relation for a room in
+        Authenticated users should not be allowed to delete a room user access for a room in
         which they are not administrator.
         """
-        relation = RoomUserFactory()
+        access = RoomUserAccessFactory()
         user = UserFactory()
         jwt_token = AccessToken.for_user(user)
 
         response = self.client.delete(
-            f"/api/rooms/{relation.room.id!s}/users/{relation.user.id!s}/",
+            f"/api/rooms/{access.room.id!s}/users/{access.user.id!s}/",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(RoomUser.objects.count(), 1)
+        self.assertEqual(RoomUserAccess.objects.count(), 1)
 
-    def test_api_room_user_relations_delete_administrator_users(self):
+    def test_api_room_user_accesss_delete_administrator_users(self):
         """
-        Authenticated users should be able to delete a room user relation for a room in which
+        Authenticated users should be able to delete a room user access for a room in which
         they are directly administrator.
         """
         user = UserFactory()
         room = RoomFactory(users=[(user, True)])
-        relation = RoomUserFactory(room=room)
+        access = RoomUserAccessFactory(room=room)
 
         jwt_token = AccessToken.for_user(user)
 
-        self.assertEqual(RoomUser.objects.count(), 2)
-        self.assertTrue(RoomUser.objects.filter(user=relation.user).exists())
+        self.assertEqual(RoomUserAccess.objects.count(), 2)
+        self.assertTrue(RoomUserAccess.objects.filter(user=access.user).exists())
         response = self.client.delete(
-            f"/api/rooms/{relation.room.id!s}/users/{relation.user.id!s}/",
+            f"/api/rooms/{access.room.id!s}/users/{access.user.id!s}/",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
         self.assertEqual(response.status_code, 204)
-        self.assertFalse(RoomUser.objects.filter(user=relation.user).exists())
+        self.assertFalse(RoomUserAccess.objects.filter(user=access.user).exists())
 
-    def test_api_room_user_relations_delete_administrator_groups(self):
+    def test_api_room_user_accesss_delete_administrator_groups(self):
         """
-        Authenticated users should be able to delete a room user relation for a room in which
+        Authenticated users should be able to delete a room user access for a room in which
         they are administrator via a group.
         """
         user = UserFactory()
         group = GroupFactory(members=[user])
-        relation = RoomUserFactory(room__groups=[(group, True)])
+        access = RoomUserAccessFactory(room__groups=[(group, True)])
 
         jwt_token = AccessToken.for_user(user)
 
         response = self.client.delete(
-            f"/api/rooms/{relation.room.id!s}/users/{relation.user.id!s}/",
+            f"/api/rooms/{access.room.id!s}/users/{access.user.id!s}/",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
         self.assertEqual(response.status_code, 204)
-        self.assertFalse(RoomUser.objects.exists())
+        self.assertFalse(RoomUserAccess.objects.exists())

--- a/tests/apps/core/test_core_api_rooms.py
+++ b/tests/apps/core/test_core_api_rooms.py
@@ -52,8 +52,8 @@ class RoomsApiTestCase(APITestCase):
 
         RoomFactory(is_public=False)
         room_public = RoomFactory(is_public=True)
-        room_groups = RoomFactory(is_public=False, groups=[group])
-        room_users = RoomFactory(is_public=False, users=[user])
+        room_group_access_accesses = RoomFactory(is_public=False, groups=[group])
+        room_user_accesses = RoomFactory(is_public=False, users=[user])
         RoomFactory(is_public=False, groups=[other_group])
         RoomFactory(is_public=False, users=[other_user])
 
@@ -64,7 +64,11 @@ class RoomsApiTestCase(APITestCase):
         self.assertEqual(response.status_code, 200)
         results = response.json()
         self.assertEqual(len(results), 3)
-        expected_ids = {str(room_public.id), str(room_groups.id), str(room_users.id)}
+        expected_ids = {
+            str(room_public.id),
+            str(room_group_access_accesses.id),
+            str(room_user_accesses.id),
+        }
         results_id = {r["id"] for r in results}
         self.assertEqual(expected_ids, results_id)
 
@@ -172,25 +176,25 @@ class RoomsApiTestCase(APITestCase):
             )
         self.assertEqual(response.status_code, 200)
 
-        user_relation = room.user_relations.first()
-        group_relation = room.group_relations.first()
+        user_access = room.user_accesses.first()
+        group_access = room.group_accesses.first()
         self.assertEqual(
             response.json(),
             {
                 "groups": [
                     {
-                        "id": str(group_relation.id),
+                        "id": str(group_access.id),
                         "group": str(group.id),
                         "room": str(room.id),
-                        "is_administrator": group_relation.is_administrator,
+                        "is_administrator": group_access.is_administrator,
                     }
                 ],
                 "users": [
                     {
-                        "id": str(user_relation.id),
+                        "id": str(user_access.id),
                         "user": str(user.id),
                         "room": str(room.id),
-                        "is_administrator": user_relation.is_administrator,
+                        "is_administrator": user_access.is_administrator,
                     }
                 ],
                 "id": str(room.id),
@@ -221,25 +225,25 @@ class RoomsApiTestCase(APITestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-        user_relation = room.user_relations.first()
-        group_relation = room.group_relations.first()
+        user_access = room.user_accesses.first()
+        group_access = room.group_accesses.first()
         self.assertEqual(
             response.json(),
             {
                 "groups": [
                     {
-                        "id": str(group_relation.id),
+                        "id": str(group_access.id),
                         "group": str(group.id),
                         "room": str(room.id),
-                        "is_administrator": group_relation.is_administrator,
+                        "is_administrator": group_access.is_administrator,
                     }
                 ],
                 "users": [
                     {
-                        "id": str(user_relation.id),
+                        "id": str(user_access.id),
                         "user": str(user.id),
                         "room": str(room.id),
-                        "is_administrator": user_relation.is_administrator,
+                        "is_administrator": user_access.is_administrator,
                     }
                 ],
                 "id": str(room.id),
@@ -280,7 +284,7 @@ class RoomsApiTestCase(APITestCase):
         self.assertEqual(response.status_code, 201)
         room = Room.objects.get()
         self.assertTrue(
-            room.user_relations.filter(is_administrator=True, user=user).exists()
+            room.user_accesses.filter(is_administrator=True, user=user).exists()
         )
 
     def test_api_rooms_create_authenticated_existing_slug(self):

--- a/tests/apps/core/test_core_models_meeting_group_relations.py
+++ b/tests/apps/core/test_core_models_meeting_group_relations.py
@@ -12,28 +12,28 @@ class MeetingGroupsModelsTestCase(TestCase):
     Unit test suite to validate the behavior of the MeetingGroup model
     """
 
-    def test_models_meeting_group_relations_str_normal(self):
+    def test_models_meeting_group_accesses_str_normal(self):
         """The str representation should consist in the meeting and group names."""
-        relation = MeetingGroupFactory(
+        access = MeetingGroupFactory(
             meeting__name="my meeting", group__name="teachers", is_administrator=False
         )
-        self.assertEqual(str(relation), "My meeting / Teachers")
+        self.assertEqual(str(access), "My meeting / Teachers")
 
-    def test_models_meeting_group_relations_str_admin(self):
+    def test_models_meeting_group_accesses_str_admin(self):
         """The str representation for an admin group should include the mention."""
-        relation = MeetingGroupFactory(
+        access = MeetingGroupFactory(
             meeting__name="my meeting", group__name="teachers", is_administrator=True
         )
-        self.assertEqual(str(relation), "My meeting / Teachers (admin)")
+        self.assertEqual(str(access), "My meeting / Teachers (admin)")
 
-    def test_models_meeting_group_relations_unique(self):
-        """Meeting group relations should be unique."""
-        relation = MeetingGroupFactory()
+    def test_models_meeting_group_accesses_unique(self):
+        """Meeting group accesses should be unique."""
+        access = MeetingGroupFactory()
 
         with self.assertRaises(ValidationError) as context:
-            MeetingGroupFactory(group=relation.group, meeting=relation.meeting)
+            MeetingGroupFactory(group=access.group, meeting=access.meeting)
 
         self.assertEqual(
             context.exception.messages,
-            ["Meeting group relation with this Group and Meeting already exists."],
+            ["Meeting group access with this Group and Meeting already exists."],
         )

--- a/tests/apps/core/test_core_models_meeting_user_relations.py
+++ b/tests/apps/core/test_core_models_meeting_user_relations.py
@@ -12,28 +12,28 @@ class MeetingUsersModelsTestCase(TestCase):
     Unit test suite to validate the behavior of the MeetingUser model
     """
 
-    def test_models_meeting_user_relations_str_normal(self):
+    def test_models_meeting_user_accesses_str_normal(self):
         """The str representation should consist in the meeting and user names."""
-        relation = MeetingUserFactory(
+        access = MeetingUserFactory(
             meeting__name="my meeting", user__name="François", is_administrator=False
         )
-        self.assertEqual(str(relation), "My meeting / François")
+        self.assertEqual(str(access), "My meeting / François")
 
-    def test_models_meeting_user_relations_str_admin(self):
+    def test_models_meeting_user_accesses_str_admin(self):
         """The str representation for an admin user should include the mention."""
-        relation = MeetingUserFactory(
+        access = MeetingUserFactory(
             meeting__name="my meeting", user__name="François", is_administrator=True
         )
-        self.assertEqual(str(relation), "My meeting / François (admin)")
+        self.assertEqual(str(access), "My meeting / François (admin)")
 
-    def test_models_meeting_user_relations_unique(self):
-        """Meeting user relations should be unique."""
-        relation = MeetingUserFactory()
+    def test_models_meeting_user_accesses_unique(self):
+        """Meeting user accesses should be unique."""
+        access = MeetingUserFactory()
 
         with self.assertRaises(ValidationError) as context:
-            MeetingUserFactory(user=relation.user, meeting=relation.meeting)
+            MeetingUserFactory(user=access.user, meeting=access.meeting)
 
         self.assertEqual(
             context.exception.messages,
-            ["Meeting user relation with this User and Meeting already exists."],
+            ["Meeting user access with this User and Meeting already exists."],
         )

--- a/tests/apps/core/test_core_models_room_group_relations.py
+++ b/tests/apps/core/test_core_models_room_group_relations.py
@@ -1,39 +1,39 @@
 """
-Unit tests for the RoomGroup model
+Unit tests for the RoomGroupAccess model
 """
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
-from magnify.apps.core.factories import RoomGroupFactory
+from magnify.apps.core.factories import RoomGroupAccessFactory
 
 
-class RoomGroupsModelsTestCase(TestCase):
+class RoomGroupAccessAccessesModelsTestCase(TestCase):
     """
-    Unit test suite to validate the behavior of the RoomGroup model
+    Unit test suite to validate the behavior of the RoomGroupAccess model
     """
 
-    def test_models_room_group_relations_str_normal(self):
+    def test_models_room_group_accesses_str_normal(self):
         """The str representation should consist in the room and group names."""
-        relation = RoomGroupFactory(
+        access = RoomGroupAccessFactory(
             room__name="my room", group__name="teachers", is_administrator=False
         )
-        self.assertEqual(str(relation), "My room / Teachers")
+        self.assertEqual(str(access), "My room / Teachers")
 
-    def test_models_room_group_relations_str_admin(self):
+    def test_models_room_group_accesses_str_admin(self):
         """The str representation for an admin group should include the mention."""
-        relation = RoomGroupFactory(
+        access = RoomGroupAccessFactory(
             room__name="my room", group__name="teachers", is_administrator=True
         )
-        self.assertEqual(str(relation), "My room / Teachers (admin)")
+        self.assertEqual(str(access), "My room / Teachers (admin)")
 
-    def test_models_room_group_relations_unique(self):
-        """Room group relations should be unique."""
-        relation = RoomGroupFactory()
+    def test_models_room_group_accesses_unique(self):
+        """Room group accesses should be unique."""
+        access = RoomGroupAccessFactory()
 
         with self.assertRaises(ValidationError) as context:
-            RoomGroupFactory(group=relation.group, room=relation.room)
+            RoomGroupAccessFactory(group=access.group, room=access.room)
 
         self.assertEqual(
             context.exception.messages,
-            ["Room group relation with this Group and Room already exists."],
+            ["Room group access with this Group and Room already exists."],
         )

--- a/tests/apps/core/test_core_models_room_user_relations.py
+++ b/tests/apps/core/test_core_models_room_user_relations.py
@@ -1,39 +1,39 @@
 """
-Unit tests for the RoomUser model
+Unit tests for the RoomUserAccess model
 """
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
-from magnify.apps.core.factories import RoomUserFactory
+from magnify.apps.core.factories import RoomUserAccessFactory
 
 
-class RoomUsersModelsTestCase(TestCase):
+class RoomUserAccessesModelsTestCase(TestCase):
     """
-    Unit test suite to validate the behavior of the RoomUser model
+    Unit test suite to validate the behavior of the RoomUserAccess model
     """
 
-    def test_models_room_user_relations_str_normal(self):
+    def test_models_room_user_accesses_str_normal(self):
         """The str representation should consist in the room and user names."""
-        relation = RoomUserFactory(
+        access = RoomUserAccessFactory(
             room__name="my room", user__name="François", is_administrator=False
         )
-        self.assertEqual(str(relation), "My room / François")
+        self.assertEqual(str(access), "My room / François")
 
-    def test_models_room_user_relations_str_admin(self):
+    def test_models_room_user_accesses_str_admin(self):
         """The str representation for an admin user should include the mention."""
-        relation = RoomUserFactory(
+        access = RoomUserAccessFactory(
             room__name="my room", user__name="François", is_administrator=True
         )
-        self.assertEqual(str(relation), "My room / François (admin)")
+        self.assertEqual(str(access), "My room / François (admin)")
 
-    def test_models_room_user_relations_unique(self):
-        """Room user relations should be unique."""
-        relation = RoomUserFactory()
+    def test_models_room_user_accesses_unique(self):
+        """Room user accesses should be unique."""
+        access = RoomUserAccessFactory()
 
         with self.assertRaises(ValidationError) as context:
-            RoomUserFactory(user=relation.user, room=relation.room)
+            RoomUserAccessFactory(user=access.user, room=access.room)
 
         self.assertEqual(
             context.exception.messages,
-            ["Room user relation with this User and Room already exists."],
+            ["Room user access with this User and Room already exists."],
         )


### PR DESCRIPTION
RoomUser is confusing, as it is not an actual user.
Same for RoomGroup.
They have been renamed to RoomUserAccess and RoomGroupAccess.
