### PR TITLE
Enable to add existing group / to create meeting in a room

### DIFF
--- a/src/frontend/magnify/src/components/meetings/CreateMeetingForm/CreateMeetingForm.stories.tsx
+++ b/src/frontend/magnify/src/components/meetings/CreateMeetingForm/CreateMeetingForm.stories.tsx
@@ -1,6 +1,6 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
 import React from 'react';
 import CreateMeetingForm from './CreateMeetingForm';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 export default {
   title: 'Meetings/CreateMeetingForm',
@@ -13,4 +13,11 @@ const Template: ComponentStory<typeof CreateMeetingForm> = (args) => (
 
 // create the template and stories
 export const basicCreateMeetingForm = Template.bind({});
-basicCreateMeetingForm.args = {};
+basicCreateMeetingForm.args = {
+  onCancel: undefined,
+};
+
+export const createMeetingFormWithCancel = Template.bind({});
+createMeetingFormWithCancel.args = {
+  onCancel: () => {},
+};

--- a/src/frontend/magnify/src/components/meetings/CreateMeetingForm/CreateMeetingForm.test.tsx
+++ b/src/frontend/magnify/src/components/meetings/CreateMeetingForm/CreateMeetingForm.test.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import { IntlProvider } from 'react-intl';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import CreateMeetingForm from './CreateMeetingForm';
-import { ControllerProvider, MockController } from '../../../controller';
+import React from 'react';
+import { IntlProvider } from 'react-intl';
 import { QueryClient, QueryClientProvider } from 'react-query';
+import { ControllerProvider, MockController } from '../../../controller';
+import CreateMeetingForm from './CreateMeetingForm';
 
 describe('CreateMeetingForm', () => {
   it('should render a form to create a meeting', async () => {
@@ -15,11 +15,13 @@ describe('CreateMeetingForm', () => {
       .spyOn(global.Date, 'now')
       .mockImplementationOnce(() => new Date(2022, 4, 24, 0, 0, 0).valueOf());
 
+    const onSuccess = jest.fn();
+
     render(
       <ControllerProvider controller={controller}>
         <QueryClientProvider client={new QueryClient()}>
           <IntlProvider locale="en">
-            <CreateMeetingForm roomSlug="room-slug" />
+            <CreateMeetingForm roomSlug="room-slug" onSuccess={onSuccess} />
           </IntlProvider>
         </QueryClientProvider>
       </ControllerProvider>,
@@ -54,5 +56,26 @@ describe('CreateMeetingForm', () => {
         expectedDuration: 30,
       });
     });
+
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it('should call the onCancel callback when the cancel button is clicked', async () => {
+    const onCancel = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+      <ControllerProvider controller={new MockController()}>
+        <QueryClientProvider client={new QueryClient()}>
+          <IntlProvider locale="en">
+            <CreateMeetingForm roomSlug="room-slug" onCancel={onCancel} />
+          </IntlProvider>
+        </QueryClientProvider>
+      </ControllerProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalled();
   });
 });

--- a/src/frontend/magnify/src/components/meetings/CreateMeetingForm/CreateMeetingForm.tsx
+++ b/src/frontend/magnify/src/components/meetings/CreateMeetingForm/CreateMeetingForm.tsx
@@ -1,6 +1,8 @@
-import { defineMessages, useIntl } from 'react-intl';
+import { Box, Button, Heading, Text } from 'grommet';
 import React from 'react';
-import { Box, Heading, Text } from 'grommet';
+import { defineMessages, useIntl } from 'react-intl';
+import { useMutation } from 'react-query';
+import { useController } from '../../../controller';
 import useFormState from '../../../hooks/useFormState';
 import validators, { requiredValidator } from '../../../utils/validators';
 import {
@@ -10,11 +12,11 @@ import {
   LoadingButton,
   TextField,
 } from '../../design-system';
-import { useController } from '../../../controller';
-import { useMutation } from 'react-query';
 
 export interface CreateMeetingFormProps {
   roomSlug?: string;
+  onCancel?: () => void;
+  onSuccess?: () => void;
 }
 
 const messages = defineMessages({
@@ -53,9 +55,14 @@ const messages = defineMessages({
     defaultMessage: 'Create meeting',
     description: 'Label for the submit button',
   },
+  cancelLabel: {
+    id: 'components.meetings.CreateMeetingForm.cancelLabel',
+    defaultMessage: 'Cancel',
+    description: 'Label for the cancel button',
+  },
 });
 
-const CreateMeetingForm = ({ roomSlug }: CreateMeetingFormProps) => {
+const CreateMeetingForm = ({ roomSlug, onCancel, onSuccess }: CreateMeetingFormProps) => {
   const intl = useIntl();
   const controller = useController();
   const { mutate, isLoading } = useMutation(controller.createMeeting);
@@ -80,11 +87,14 @@ const CreateMeetingForm = ({ roomSlug }: CreateMeetingFormProps) => {
   );
 
   const handleSubmit = async () => {
-    mutate({
-      roomSlug,
-      ...values,
-      expectedDuration: parseInt(values.expectedDuration, 10),
-    });
+    mutate(
+      {
+        roomSlug,
+        ...values,
+        expectedDuration: parseInt(values.expectedDuration, 10),
+      },
+      { onSuccess: onSuccess },
+    );
   };
 
   return (
@@ -156,6 +166,15 @@ const CreateMeetingForm = ({ roomSlug }: CreateMeetingFormProps) => {
         </Fieldset>
 
         <Box justify="end" direction="row">
+          {onCancel && (
+            <Button
+              label={intl.formatMessage(messages.cancelLabel)}
+              onClick={onCancel}
+              onFocus={(event: React.FocusEvent) => event.stopPropagation()}
+              margin={{ right: 'small' }}
+            />
+          )}
+
           <LoadingButton
             primary
             isLoading={isLoading}

--- a/src/frontend/magnify/src/components/rooms/CreateMeetingInRoomDialog/CreateMeetingInRoomDialog.stories.tsx
+++ b/src/frontend/magnify/src/components/rooms/CreateMeetingInRoomDialog/CreateMeetingInRoomDialog.stories.tsx
@@ -1,0 +1,20 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import React from 'react';
+import CreateMeetingInRoomDialog from './CreateMeetingInRoomDialog';
+
+export default {
+  title: 'Rooms/CreateMeetingInRoomDialog',
+  component: CreateMeetingInRoomDialog,
+} as ComponentMeta<typeof CreateMeetingInRoomDialog>;
+
+const Template: ComponentStory<typeof CreateMeetingInRoomDialog> = (args) => (
+  <CreateMeetingInRoomDialog {...args} />
+);
+
+// create the template and stories
+export const basicCreateMeetingInRoomDialog = Template.bind({});
+basicCreateMeetingInRoomDialog.args = {
+  open: true,
+  onClose: () => {},
+  roomSlug: 'room-slug',
+};

--- a/src/frontend/magnify/src/components/rooms/CreateMeetingInRoomDialog/CreateMeetingInRoomDialog.test.tsx
+++ b/src/frontend/magnify/src/components/rooms/CreateMeetingInRoomDialog/CreateMeetingInRoomDialog.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { ControllerProvider, MockController } from '../../../controller';
+import CreateMeetingInRoomDialog from './CreateMeetingInRoomDialog';
+
+describe('CreateMeetingInRoomDialog', () => {
+  it('should provide a cancel button', () => {
+    const controller = new MockController();
+    const onClose = jest.fn();
+
+    render(
+      <IntlProvider locale="en">
+        <ControllerProvider controller={controller}>
+          <QueryClientProvider client={new QueryClient()}>
+            <CreateMeetingInRoomDialog open={true} onClose={onClose} roomSlug="room-slug" />
+          </QueryClientProvider>
+        </ControllerProvider>
+      </IntlProvider>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  it('should provide a form', () => {
+    const controller = new MockController();
+    const onClose = jest.fn();
+
+    render(
+      <IntlProvider locale="en">
+        <ControllerProvider controller={controller}>
+          <QueryClientProvider client={new QueryClient()}>
+            <CreateMeetingInRoomDialog open={true} onClose={onClose} roomSlug="room-slug" />
+          </QueryClientProvider>
+        </ControllerProvider>
+      </IntlProvider>,
+    );
+
+    expect(document.querySelector('form')).toBeInTheDocument();
+  });
+
+  // Other behaviours have mostly be tested
+  // in the CreateMeetingForm component.
+});

--- a/src/frontend/magnify/src/components/rooms/CreateMeetingInRoomDialog/CreateMeetingInRoomDialog.tsx
+++ b/src/frontend/magnify/src/components/rooms/CreateMeetingInRoomDialog/CreateMeetingInRoomDialog.tsx
@@ -1,0 +1,30 @@
+import { Box, Layer } from 'grommet';
+import React from 'react';
+
+import { CreateMeetingForm } from '../../meetings';
+
+export interface CreateMeetingInRoomDialogProps {
+  open: boolean;
+  onClose: () => void;
+  roomSlug: string;
+}
+
+const CreateMeetingInRoomDialog = ({ open, onClose, roomSlug }: CreateMeetingInRoomDialogProps) => {
+  if (!open) return null;
+  return (
+    <Layer
+      id="confirmDelete"
+      position="center"
+      onClickOutside={onClose}
+      onEsc={onClose}
+      role="dialog"
+      modal
+    >
+      <Box pad="medium" width="large" overflow={'auto'}>
+        <CreateMeetingForm roomSlug={roomSlug} onCancel={onClose} onSuccess={onClose} />
+      </Box>
+    </Layer>
+  );
+};
+
+export default CreateMeetingInRoomDialog;

--- a/src/frontend/magnify/src/components/rooms/CreateMeetingInRoomDialog/index.ts
+++ b/src/frontend/magnify/src/components/rooms/CreateMeetingInRoomDialog/index.ts
@@ -1,0 +1,1 @@
+export { default, CreateMeetingInRoomDialogProps } from './CreateMeetingInRoomDialog';

--- a/src/frontend/magnify/src/components/rooms/RoomOverview/RoomOverview.tsx
+++ b/src/frontend/magnify/src/components/rooms/RoomOverview/RoomOverview.tsx
@@ -1,11 +1,12 @@
-import { defineMessages, useIntl } from 'react-intl';
-import React from 'react';
 import { Box, Button, Card } from 'grommet';
-import { useController } from '../../../controller';
+import React, { useState } from 'react';
+import { defineMessages, useIntl } from 'react-intl';
 import { useQuery } from 'react-query';
+import { useController } from '../../../controller';
 import { LoadingButton, RowsList, SettingsSVG } from '../../design-system';
-import MeetingRow from '../../meetings/MeetingRow/MeetingRow';
 import { GroupRow } from '../../groups';
+import MeetingRow from '../../meetings/MeetingRow/MeetingRow';
+import AddGroupToRoomDialog from '../AddGroupToRoomDialog';
 
 const messages = defineMessages({
   meetingListTitle: {
@@ -30,6 +31,11 @@ const messages = defineMessages({
     defaultMessage: 'Configure room',
     description: 'Label for the button to configure a room',
   },
+  addGroupLabel: {
+    id: 'components.rooms.roomOverview.addGroupLabel',
+    defaultMessage: 'Add group',
+    description: 'Label for the button to add a group to a room',
+  },
 });
 
 export interface RoomOverviewProps {
@@ -50,6 +56,14 @@ const RoomOverview = ({ roomSlug, baseJitsiUrl }: RoomOverviewProps) => {
   const { data: room, isLoading } = useQuery(['room', roomSlug], () =>
     controller.getRoomBySlug(roomSlug),
   );
+
+  const [addGroupOpen, setAddGroupOpen] = useState(false);
+  const handleAddGroupOpen = () => {
+    setAddGroupOpen(true);
+  };
+  const handleAddGroupClose = () => {
+    setAddGroupOpen(false);
+  };
 
   return (
     <>
@@ -82,8 +96,11 @@ const RoomOverview = ({ roomSlug, baseJitsiUrl }: RoomOverviewProps) => {
           isLoading={isLoading}
           titleIsLoading={isLoading}
           Row={GroupRow}
+          addLabel={intl.formatMessage(messages.addGroupLabel)}
+          onAdd={handleAddGroupOpen}
         />
       </Box>
+      <AddGroupToRoomDialog open={addGroupOpen} onClose={handleAddGroupClose} roomSlug={roomSlug} />
     </>
   );
 };

--- a/src/frontend/magnify/src/components/rooms/RoomOverview/RoomOverview.tsx
+++ b/src/frontend/magnify/src/components/rooms/RoomOverview/RoomOverview.tsx
@@ -7,6 +7,7 @@ import { LoadingButton, RowsList, SettingsSVG } from '../../design-system';
 import { GroupRow } from '../../groups';
 import MeetingRow from '../../meetings/MeetingRow/MeetingRow';
 import AddGroupToRoomDialog from '../AddGroupToRoomDialog';
+import CreateMeetingInRoomDialog from '../CreateMeetingInRoomDialog';
 
 const messages = defineMessages({
   meetingListTitle: {
@@ -35,6 +36,11 @@ const messages = defineMessages({
     id: 'components.rooms.roomOverview.addGroupLabel',
     defaultMessage: 'Add group',
     description: 'Label for the button to add a group to a room',
+  },
+  createMeetingLabel: {
+    id: 'components.rooms.roomOverview.createMeetingLabel',
+    defaultMessage: 'New meeting',
+    description: 'Label for the button to create a meeting in a room',
   },
 });
 
@@ -65,6 +71,14 @@ const RoomOverview = ({ roomSlug, baseJitsiUrl }: RoomOverviewProps) => {
     setAddGroupOpen(false);
   };
 
+  const [createMeetingOpen, setCreateMeetingOpen] = useState(false);
+  const handleCreateMeetingOpen = () => {
+    setCreateMeetingOpen(true);
+  };
+  const handleCreateMeetingClose = () => {
+    setCreateMeetingOpen(false);
+  };
+
   return (
     <>
       <Card background="white" direction="row" justify="end" pad="medium">
@@ -87,6 +101,8 @@ const RoomOverview = ({ roomSlug, baseJitsiUrl }: RoomOverviewProps) => {
           Row={({ meeting }) => <MeetingRow meeting={meeting} baseJitsiUrl={baseJitsiUrl} />}
           isLoading={isLoading}
           titleIsLoading={isLoading}
+          addLabel={intl.formatMessage(messages.createMeetingLabel)}
+          onAdd={handleCreateMeetingOpen}
         />
       </Box>
       <Box margin={{ top: 'medium' }}>
@@ -100,6 +116,11 @@ const RoomOverview = ({ roomSlug, baseJitsiUrl }: RoomOverviewProps) => {
           onAdd={handleAddGroupOpen}
         />
       </Box>
+      <CreateMeetingInRoomDialog
+        open={createMeetingOpen}
+        onClose={handleCreateMeetingClose}
+        roomSlug={roomSlug}
+      />
       <AddGroupToRoomDialog open={addGroupOpen} onClose={handleAddGroupClose} roomSlug={roomSlug} />
     </>
   );

--- a/src/frontend/magnify/src/components/rooms/index.ts
+++ b/src/frontend/magnify/src/components/rooms/index.ts
@@ -6,3 +6,4 @@ export { default as RoomConfig } from './RoomConfig';
 export { default as RoomOverview } from './RoomOverview';
 export { default as RoomSettingsBlock } from './RoomSettingsBlock';
 export { default as RoomSettingToggle } from './RoomSettingToggle';
+export { default as CreateMeetingInRoomDialog } from './CreateMeetingInRoomDialog';


### PR DESCRIPTION
## Purpose

Enables to add groups and meetings in the room overview.

## Proposal

- Linking the current `AddGroupToRoomDialog` to the `onAdd` prop of the `RowsList`
- Add a `CreateMeetingInRoomDialog` that uses the `CreateMeetingForm`, and linking it to the `onAdd` prop of the `RowsList`