### PR TITLE
Add a view to present a single group and add users

### DIFF
--- a/src/frontend/demo/src/App.tsx
+++ b/src/frontend/demo/src/App.tsx
@@ -3,6 +3,7 @@ import { Box } from 'grommet';
 import { Route, Routes } from 'react-router-dom';
 import NotFoundView from './views/404';
 import DefaultView from './views/default';
+import GroupView from './views/group';
 import GroupsView from './views/groups';
 import ProfileView from './views/profile';
 import RoomView from './views/room';
@@ -33,6 +34,7 @@ export default function App() {
         <Route path="/" element={<DefaultView />} />
         <Route path="/account" element={<ProfileView />} />
         <Route path="/groups" element={<GroupsView />} />
+        <Route path="/groups/:groupId" element={<GroupView />} />
         <Route path="/rooms" element={<RoomsView />} />
         <Route path="/rooms/:slug" element={<RoomView />} />
         <Route path="/rooms/:slug/settings" element={<RoomSettingsView />} />

--- a/src/frontend/demo/src/views/group.tsx
+++ b/src/frontend/demo/src/views/group.tsx
@@ -1,0 +1,23 @@
+import { LayoutWithSidebar, useTranslations, GroupUserList } from '@jitsi-magnify/core';
+import { defineMessages } from 'react-intl';
+import { useParams } from 'react-router-dom';
+
+export const messages = defineMessages({
+  groupViewTitle: {
+    id: 'app.groupViewTitle',
+    description: 'Page title for the My Group page',
+    defaultMessage: 'Group',
+  },
+});
+
+export default function GroupView() {
+  const intl = useTranslations();
+  const { groupId } = useParams();
+
+  if (!groupId) return null;
+  return (
+    <LayoutWithSidebar title={intl.formatMessage(messages.groupViewTitle)}>
+      <GroupUserList groupId={groupId} />
+    </LayoutWithSidebar>
+  );
+}

--- a/src/frontend/magnify/src/components/groups/AddUserForm/AddUserForm.stories.tsx
+++ b/src/frontend/magnify/src/components/groups/AddUserForm/AddUserForm.stories.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import AddUserForm from './AddUserForm';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'Groups/AddUserForm',
+  component: AddUserForm,
+} as ComponentMeta<typeof AddUserForm>;
+
+const Template: ComponentStory<typeof AddUserForm> = (args) => <AddUserForm {...args} />;
+
+// create the template and stories
+export const basicAddUserForm = Template.bind({});
+basicAddUserForm.args = {};

--- a/src/frontend/magnify/src/components/groups/AddUserForm/AddUserForm.test.tsx
+++ b/src/frontend/magnify/src/components/groups/AddUserForm/AddUserForm.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+import AddUserForm from './AddUserForm';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import userEvent from '@testing-library/user-event';
+import { ControllerProvider, MockController } from '../../../controller';
+import createRandomGroup from '../../../factories/group';
+
+describe('AddUserForm', () => {
+  it('should render successfully', async () => {
+    const controller = new MockController();
+    controller.addUserToGroup.mockResolvedValue(createRandomGroup(7));
+    const user = userEvent.setup();
+
+    render(
+      <IntlProvider locale="en">
+        <QueryClientProvider client={new QueryClient()}>
+          <ControllerProvider controller={controller}>
+            <AddUserForm groupId="group-id" />
+          </ControllerProvider>
+        </QueryClientProvider>
+      </IntlProvider>,
+    );
+
+    await user.type(screen.getByRole('textbox', { name: 'Email' }), 'test@test.fr');
+    await user.click(screen.getByRole('button', { name: 'Add user' }));
+    await waitFor(() =>
+      expect(controller.addUserToGroup).toHaveBeenCalledWith({
+        groupId: 'group-id',
+        userEmail: 'test@test.fr',
+      }),
+    );
+  });
+});

--- a/src/frontend/magnify/src/components/groups/AddUserForm/AddUserForm.tsx
+++ b/src/frontend/magnify/src/components/groups/AddUserForm/AddUserForm.tsx
@@ -1,0 +1,83 @@
+import { defineMessages, useIntl } from 'react-intl';
+import React from 'react';
+import useFormState from '../../../hooks/useFormState';
+import validators, { emailValidator, requiredValidator } from '../../../utils/validators';
+import { LoadingButton, TextField } from '../../design-system';
+import { Box, Button, Heading } from 'grommet';
+import { useController } from '../../../controller';
+import { useMutation, useQueryClient } from 'react-query';
+import { Group } from '../../../types/group';
+
+export interface AddUserFormProps {
+  onSuccess?: () => void;
+  onCancel?: () => void;
+  groupId: string;
+}
+
+const messages = defineMessages({
+  email: {
+    id: 'components.groups.AddUserForm.email',
+    defaultMessage: 'Email',
+    description: 'Email label',
+  },
+  addUserHeading: {
+    id: 'components.groups.AddUserForm.addUserHeading',
+    defaultMessage: 'Add user to group',
+    description: 'Add user heading',
+  },
+  addUserSubmitLabel: {
+    id: 'components.groups.AddUserForm.addUserSubmitLabel',
+    defaultMessage: 'Add user',
+    description: 'Add user button label',
+  },
+  cancel: {
+    id: 'components.groups.AddUserForm.cancel',
+    defaultMessage: 'Cancel',
+    description: 'Cancel button label',
+  },
+});
+
+const AddUserForm = ({ onSuccess, onCancel, groupId }: AddUserFormProps) => {
+  const intl = useIntl();
+  const controller = useController();
+  const queryClient = useQueryClient();
+  const { mutate, isLoading } = useMutation(controller.addUserToGroup, {
+    onSuccess: (data) => {
+      queryClient.setQueryData(['group', groupId], () => data);
+      onSuccess?.();
+    },
+  });
+
+  const { values, setValue, errors, modified, isModified, isValid } = useFormState(
+    { email: '' },
+    { email: validators(intl, requiredValidator, emailValidator) },
+  );
+
+  return (
+    <>
+      <Heading level={3}>{intl.formatMessage(messages.addUserHeading)}</Heading>
+      <TextField
+        label={intl.formatMessage(messages.email)}
+        name="email"
+        value={values.email}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          setValue('email', e.currentTarget.value)
+        }
+        errors={errors.email}
+        displayErrors={modified.email}
+      />
+      <Box direction="row" justify="end" margin={{ top: 'medium' }} gap="small">
+        <Button onClick={onCancel} label={intl.formatMessage(messages.cancel)} />
+        <LoadingButton
+          label={intl.formatMessage(messages.addUserSubmitLabel)}
+          primary
+          onClick={() => mutate({ groupId, userEmail: values.email })}
+          isLoading={isLoading}
+          disabled={!isModified || !isValid}
+        />
+      </Box>
+    </>
+  );
+};
+
+export default AddUserForm;

--- a/src/frontend/magnify/src/components/groups/AddUserForm/index.ts
+++ b/src/frontend/magnify/src/components/groups/AddUserForm/index.ts
@@ -1,0 +1,1 @@
+export { default, AddUserFormProps } from './AddUserForm';

--- a/src/frontend/magnify/src/components/groups/GroupRow/GroupRow.test.tsx
+++ b/src/frontend/magnify/src/components/groups/GroupRow/GroupRow.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from '@testing-library/react';
 import GroupRow from './GroupRow';
 import { ResponsiveContext } from 'grommet';
 import createRandomGroup from '../../../factories/group';
+import { MemoryRouter } from 'react-router-dom';
 
 describe('GroupRow', () => {
   it.each([
@@ -24,7 +25,9 @@ describe('GroupRow', () => {
 
       render(
         <ResponsiveContext.Provider value={width}>
-          <GroupRow group={group} selected={false} onToggle={() => {}} />
+          <MemoryRouter>
+            <GroupRow group={group} selected={false} onToggle={() => {}} />
+          </MemoryRouter>
         </ResponsiveContext.Provider>,
       );
 
@@ -64,7 +67,13 @@ describe('GroupRow', () => {
       const user = userEvent.setup();
 
       render(
-        <GroupRow group={createRandomGroup(9)} selected={initialChecked} onToggle={mockedToggle} />,
+        <MemoryRouter>
+          <GroupRow
+            group={createRandomGroup(9)}
+            selected={initialChecked}
+            onToggle={mockedToggle}
+          />
+        </MemoryRouter>,
       );
 
       await user.click(screen.getByTitle('Select Group'));

--- a/src/frontend/magnify/src/components/groups/GroupRow/GroupRow.tsx
+++ b/src/frontend/magnify/src/components/groups/GroupRow/GroupRow.tsx
@@ -3,6 +3,7 @@ import React, { ChangeEvent, useContext } from 'react';
 import { More } from 'grommet-icons';
 import { Group } from '../../../types/group';
 import { SquareAvatar } from '../../design-system';
+import { Link } from 'react-router-dom';
 
 export interface GroupRowProps {
   /**
@@ -55,9 +56,11 @@ export default function GroupRow({ group, onToggle, selected }: GroupRowProps) {
         </Box>
         <Box gridArea="title">
           <Box margin="auto 0px">
-            <Text size="medium" color="brand" weight="bold">
-              {group.name}
-            </Text>
+            <Link to={`/groups/${group.id}`}>
+              <Text size="medium" color="brand" weight="bold">
+                {group.name}
+              </Text>
+            </Link>
           </Box>
         </Box>
         <Box

--- a/src/frontend/magnify/src/components/groups/GroupUserList/GroupUserList.stories.tsx
+++ b/src/frontend/magnify/src/components/groups/GroupUserList/GroupUserList.stories.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import GroupUserList from './GroupUserList';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'Groups/GroupUserList',
+  component: GroupUserList,
+} as ComponentMeta<typeof GroupUserList>;
+
+const Template: ComponentStory<typeof GroupUserList> = (args) => <GroupUserList {...args} />;
+
+// create the template and stories
+export const basicGroupUserList = Template.bind({});
+basicGroupUserList.args = {};

--- a/src/frontend/magnify/src/components/groups/GroupUserList/GroupUserList.test.tsx
+++ b/src/frontend/magnify/src/components/groups/GroupUserList/GroupUserList.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+import userEvent from '@testing-library/user-event';
+import GroupUserList from './GroupUserList';
+import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { ControllerProvider, MockController } from '../../../controller';
+import createRandomGroup from '../../../factories/group';
+import { MemoryRouter } from 'react-router-dom';
+
+describe('GroupUserList', () => {
+  it('should render successfully', async () => {
+    const controller = new MockController();
+    controller.getGroup.mockResolvedValue(createRandomGroup(7));
+    const user = userEvent.setup();
+
+    render(
+      <IntlProvider locale="en">
+        <QueryClientProvider client={new QueryClient()}>
+          <ControllerProvider controller={controller}>
+            <MemoryRouter>
+              <GroupUserList groupId="group-id" />
+            </MemoryRouter>
+          </ControllerProvider>
+        </QueryClientProvider>
+      </IntlProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Add user to group' }));
+    await screen.findByRole('textbox', { name: 'Email' });
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    await waitForElementToBeRemoved(() => screen.getByRole('button', { name: 'Cancel' }));
+  });
+});

--- a/src/frontend/magnify/src/components/groups/GroupUserList/GroupUserList.tsx
+++ b/src/frontend/magnify/src/components/groups/GroupUserList/GroupUserList.tsx
@@ -1,0 +1,62 @@
+import { defineMessages, useIntl } from 'react-intl';
+import React from 'react';
+import { RowsList } from '../../design-system';
+import { useController } from '../../../controller';
+import { useQuery } from 'react-query';
+import { UserRow } from '../../users';
+import { Box, Layer } from 'grommet';
+import AddUserForm from '../AddUserForm';
+
+export interface GroupUserListProps {
+  groupId: string;
+}
+
+const messages = defineMessages({
+  usersLabel: {
+    id: 'components.groups.GroupUserList.usersLabel',
+    defaultMessage: 'Users',
+    description: 'Users label',
+  },
+  addUserToGroupLabel: {
+    id: 'components.groups.GroupUserList.addUserToGroupLabel',
+    defaultMessage: 'Add user to group',
+    description: 'Add user to group label',
+  },
+});
+
+const GroupUserList = ({ groupId }: GroupUserListProps) => {
+  const intl = useIntl();
+  const [openAddUser, setOpenAddUser] = React.useState(false);
+  const controller = useController();
+  const { data: group, isLoading } = useQuery(['group', groupId], () =>
+    controller.getGroup(groupId),
+  );
+
+  const handleCloseAddUser = () => setOpenAddUser(false);
+
+  return (
+    <>
+      <RowsList
+        label={messages.usersLabel}
+        addLabel={intl.formatMessage(messages.addUserToGroupLabel)}
+        onAdd={() => setOpenAddUser(true)}
+        Row={({ user }) => <UserRow user={user} />}
+        rows={(group?.members || []).map((user) => ({ user, id: user.id }))}
+        isLoading={isLoading}
+      />
+      {openAddUser && (
+        <Layer onClickOutside={handleCloseAddUser} onEsc={handleCloseAddUser}>
+          <Box pad="medium">
+            <AddUserForm
+              groupId={groupId}
+              onSuccess={handleCloseAddUser}
+              onCancel={handleCloseAddUser}
+            />
+          </Box>
+        </Layer>
+      )}
+    </>
+  );
+};
+
+export default GroupUserList;

--- a/src/frontend/magnify/src/components/groups/GroupUserList/index.ts
+++ b/src/frontend/magnify/src/components/groups/GroupUserList/index.ts
@@ -1,0 +1,1 @@
+export { default, GroupUserListProps } from './GroupUserList';

--- a/src/frontend/magnify/src/components/groups/GroupsList/GroupsList.test.tsx
+++ b/src/frontend/magnify/src/components/groups/GroupsList/GroupsList.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from '@testing-library/react';
 import GroupsList from './GroupsList';
 import { IntlProvider } from 'react-intl';
 import createRandomGroup from '../../../factories/group';
+import { MemoryRouter } from 'react-router-dom';
 
 // Mocks
 const mockedGroups = [
@@ -18,7 +19,9 @@ describe('GroupsList', () => {
     const user = userEvent.setup();
     render(
       <IntlProvider locale="en">
-        <GroupsList groups={mockedGroups} />
+        <MemoryRouter>
+          <GroupsList groups={mockedGroups} />
+        </MemoryRouter>
       </IntlProvider>,
     );
 
@@ -44,7 +47,9 @@ describe('GroupsList', () => {
     const user = userEvent.setup();
     render(
       <IntlProvider locale="en">
-        <GroupsList groups={mockedGroups} />
+        <MemoryRouter>
+          <GroupsList groups={mockedGroups} />
+        </MemoryRouter>
       </IntlProvider>,
     );
 

--- a/src/frontend/magnify/src/components/groups/MyGroupsBlock/MyGroupsBlock.test.tsx
+++ b/src/frontend/magnify/src/components/groups/MyGroupsBlock/MyGroupsBlock.test.tsx
@@ -5,6 +5,7 @@ import { render, screen } from '@testing-library/react';
 import { ControllerProvider, MockController } from '../../../controller';
 import createRandomGroups from '../../../factories/groups';
 import { QueryClient, QueryClientProvider } from 'react-query';
+import { MemoryRouter } from 'react-router-dom';
 
 describe('MyGroupsBlock', () => {
   it('should load a list of groups', async () => {
@@ -16,7 +17,9 @@ describe('MyGroupsBlock', () => {
       <ControllerProvider controller={controller}>
         <QueryClientProvider client={new QueryClient()}>
           <IntlProvider locale="en">
-            <MyGroupsBlock />
+            <MemoryRouter>
+              <MyGroupsBlock />
+            </MemoryRouter>
           </IntlProvider>
         </QueryClientProvider>
       </ControllerProvider>,

--- a/src/frontend/magnify/src/components/groups/index.ts
+++ b/src/frontend/magnify/src/components/groups/index.ts
@@ -2,3 +2,5 @@ export { default as GroupRow, GroupRowProps } from './GroupRow';
 export { default as GroupsList, GroupsListProps } from './GroupsList';
 export { default as GroupsHeader, GroupsHeaderProps } from './GroupsHeader';
 export { default as MyGroupsBlock } from './MyGroupsBlock';
+export { default as AddUserForm } from './AddUserForm';
+export { default as GroupUserList } from './GroupUserList';

--- a/src/frontend/magnify/src/controller/default.controller.ts
+++ b/src/frontend/magnify/src/controller/default.controller.ts
@@ -86,6 +86,12 @@ export default class DefaultController extends Controller {
     // GET /groups
     throw new Error('Not implemented');
   }
+  async getGroup(): Promise<Group> {
+    throw new Error('Not implemented');
+  }
+  async addUserToGroup(): Promise<Group> {
+    throw new Error('Not implemented');
+  }
 
   async getMeeting(meetingId: string): Promise<WithToken<Meeting>> {
     throw new Error('Not implemented');

--- a/src/frontend/magnify/src/controller/interface.ts
+++ b/src/frontend/magnify/src/controller/interface.ts
@@ -50,6 +50,10 @@ export interface CreateMeetingInput {
   startTime: string;
   expectedDuration: number;
 }
+export interface AddUserToGroupInput {
+  groupId: string;
+  userEmail: string;
+}
 
 export interface UpdateRoomSettingsInput {
   name: string;
@@ -86,6 +90,8 @@ export default abstract class Controller {
 
   // Groups
   abstract getGroups(): Promise<Group[]>;
+  abstract getGroup(groupId: string): Promise<Group>;
+  abstract addUserToGroup(input: AddUserToGroupInput): Promise<Group>;
 
   // Meetings
   abstract getMeeting(meetingId: string): Promise<WithToken<Meeting>>;

--- a/src/frontend/magnify/src/controller/log.controller.ts
+++ b/src/frontend/magnify/src/controller/log.controller.ts
@@ -1,3 +1,4 @@
+import createRandomGroup from '../factories/group';
 import createRandomGroups from '../factories/groups';
 import { createMeetingInProgress, createRandomMeeting } from '../factories/meeting';
 import { createRandomProfile } from '../factories/profile';
@@ -12,6 +13,7 @@ import { AccessToken, Tokens } from '../types/tokens';
 import { WithToken } from '../types/withToken';
 import Controller, {
   AddGroupsToRoomInput,
+  AddUserToGroupInput,
   CreateMeetingInput,
   LoginInput,
   SignupInput,
@@ -223,6 +225,19 @@ export default class LogController extends Controller {
     'getGroups',
     new MockControllerFunction<null, Group[]>().resolveOnDefault(createRandomGroups(7)),
   );
+  getGroup = promisifiedConsoleLogFactory(
+    this,
+    'getGroup',
+    new MockControllerFunction<string, Group>().resolveOnDefault(createRandomGroup(6)),
+  );
+  addUserToGroup = (input: AddUserToGroupInput) =>
+    promisifiedConsoleLogFactory(
+      this,
+      'addUserToGroup',
+      new MockControllerFunction<AddUserToGroupInput, Group>().resolveOnDefault(
+        createRandomGroup(7),
+      ),
+    )(input);
 
   // Meetings
   joinMeeting = promisifiedConsoleLogFactory(

--- a/src/frontend/magnify/src/controller/mock.controller.ts
+++ b/src/frontend/magnify/src/controller/mock.controller.ts
@@ -18,6 +18,8 @@ export default class MockController extends Controller {
   deleteUser = jest.fn();
 
   getGroups = jest.fn();
+  getGroup = jest.fn();
+  addUserToGroup = jest.fn();
 
   joinMeeting = jest.fn();
   createMeeting = jest.fn();


### PR DESCRIPTION
## Purpose

This is straight forward. We use the abstractions we previously build
to add a form, a dialog and a list of users to present a single group

![Screenshot from 2022-07-12 10-00-52](https://user-images.githubusercontent.com/25184106/178440344-c33ef276-9a6b-46dd-b080-07974c1d8a39.png)
