### PR TITLE
✨(api) add jitsi room name to API and ensure their unicity

### DIFF
--- a/src/magnify/apps/core/models.py
+++ b/src/magnify/apps/core/models.py
@@ -199,6 +199,11 @@ class Room(BaseModel):
         self.slug = slugify(self.name)
         super().save(*args, **kwargs)
 
+    @property
+    def jitsi_name(self):
+        """The name used for the room in Jitsi."""
+        return f"{self.slug:s}-{self.id!s}"
+
     def is_administrator(self, user):
         """check if a user is administrator of the room."""
         if not user.is_authenticated:
@@ -337,6 +342,14 @@ class Meeting(BaseModel):
 
     def __str__(self):
         return self.name
+
+    @property
+    def jitsi_name(self):
+        """The name used for the room in Jitsi."""
+        # Get a unique identifier for the meeing
+        if self.room:
+            return f"{self.room.slug:s}-{self.id!s}"
+        return str(self.id)
 
     def reset_recurrence(self):
         """

--- a/src/magnify/apps/core/serializers/meetings.py
+++ b/src/magnify/apps/core/serializers/meetings.py
@@ -10,7 +10,7 @@ from magnify.apps.core.utils import generate_token
 class MeetingSerializer(serializers.ModelSerializer):
     """Serialize Meeting model for the API."""
 
-    token = serializers.SerializerMethodField()
+    jitsi = serializers.SerializerMethodField()
     occurrences = serializers.SerializerMethodField()
 
     class Meta:
@@ -21,6 +21,7 @@ class MeetingSerializer(serializers.ModelSerializer):
             "frequency",
             "groups",
             "is_public",
+            "jitsi",
             "labels",
             "monthly_type",
             "name",
@@ -30,7 +31,6 @@ class MeetingSerializer(serializers.ModelSerializer):
             "room",
             "start",
             "start_time",
-            "token",
             "users",
             "recurring_until",
             "weekdays",
@@ -38,11 +38,14 @@ class MeetingSerializer(serializers.ModelSerializer):
         read_only_fields = ["id", "token"]
         extra_kwargs = {"recurring_until": {"required": False}}
 
-    def get_token(self, obj):
-        """Generate and insert the token in the serializer under the "token" field."""
+    def get_jitsi(self, obj):
+        """Generate and insert the jitsi credentials in the serializer under the "jitsi" field."""
         if request := self.context.get("request"):
-            return generate_token(request.user, f"{obj.room.slug:s}-{obj.id!s}")
-        return ""
+            return {
+                "room": obj.jitsi_name,
+                "token": generate_token(request.user, obj.jitsi_name),
+            }
+        return None
 
     @staticmethod
     def get_occurrences(obj):

--- a/src/magnify/apps/core/serializers/rooms.py
+++ b/src/magnify/apps/core/serializers/rooms.py
@@ -78,7 +78,10 @@ class RoomSerializer(serializers.ModelSerializer):
                 or instance.group_accesses.filter(group__user_accesses__user=user)
             )
         ):
-            output["token"] = generate_token(user, instance.slug)
+            output["jitsi"] = {
+                "room": instance.jitsi_name,
+                "token": generate_token(user, instance.jitsi_name),
+            }
 
         if instance.is_administrator(request.user):
             groups_serializer = RoomGroupAccessSerializer(

--- a/tests/apps/core/test_core_api_rooms.py
+++ b/tests/apps/core/test_core_api_rooms.py
@@ -31,9 +31,12 @@ class RoomsApiTestCase(APITestCase):
             results[0],
             {
                 "id": str(room_public.id),
+                "jitsi": {
+                    "room": f"{room_public.slug:s}-{room_public.id!s}",
+                    "token": "the token",
+                },
                 "name": room_public.name,
                 "slug": room_public.slug,
-                "token": "the token",
             },
         )
         mock_token.assert_called_once()
@@ -105,9 +108,12 @@ class RoomsApiTestCase(APITestCase):
             response.json(),
             {
                 "id": str(room.id),
+                "jitsi": {
+                    "room": f"{room.slug:s}-{room.id!s}",
+                    "token": "the token",
+                },
                 "name": room.name,
                 "slug": room.slug,
-                "token": "the token",
             },
         )
         mock_token.assert_called_once()
@@ -135,12 +141,15 @@ class RoomsApiTestCase(APITestCase):
             response.json(),
             {
                 "id": str(room.id),
+                "jitsi": {
+                    "room": f"{room.slug:s}-{room.id!s}",
+                    "token": "the token",
+                },
                 "name": room.name,
                 "slug": room.slug,
-                "token": "the token",
             },
         )
-        mock_token.assert_called_once_with(user, room.slug)
+        mock_token.assert_called_once_with(user, f"{room.slug:s}-{room.id!s}")
 
     def test_api_rooms_retrieve_authenticated(self):
         """
@@ -208,12 +217,18 @@ class RoomsApiTestCase(APITestCase):
                     }
                 ],
                 "id": str(room.id),
+                "jitsi": {
+                    "room": f"{room.slug:s}-{room.id!s}",
+                    "token": "the token",
+                },
                 "name": room.name,
                 "slug": room.slug,
-                "token": "the token",
             },
         )
-        mock_token.assert_called_once_with(user, room.slug)
+        mock_token.assert_called_once_with(
+            user,
+            f"{room.slug:s}-{room.id!s}",
+        )
 
     @mock.patch(
         "magnify.apps.core.serializers.rooms.generate_token", return_value="the token"
@@ -257,12 +272,15 @@ class RoomsApiTestCase(APITestCase):
                     }
                 ],
                 "id": str(room.id),
+                "jitsi": {
+                    "room": f"{room.slug:s}-{room.id!s}",
+                    "token": "the token",
+                },
                 "name": room.name,
                 "slug": room.slug,
-                "token": "the token",
             },
         )
-        mock_token.assert_called_once_with(administrator, room.slug)
+        mock_token.assert_called_once_with(administrator, f"{room.slug:s}-{room.id!s}")
 
     def test_api_rooms_create_anonymous(self):
         """Anonymous users should not be allowed to create rooms."""

--- a/tests/apps/core/test_core_api_rooms_meetings.py
+++ b/tests/apps/core/test_core_api_rooms_meetings.py
@@ -57,6 +57,10 @@ class RoomMeetingsApiTestCase(APITestCase):
                 "frequency": 1,
                 "groups": [],
                 "is_public": True,
+                "jitsi": {
+                    "room": f"{meeting.room.slug:s}-{meeting.id!s}",
+                    "token": "the token",
+                },
                 "labels": [],
                 "monthly_type": "date_day",
                 "name": meeting.name,
@@ -70,7 +74,6 @@ class RoomMeetingsApiTestCase(APITestCase):
                 "room": str(room.id),
                 "start": meeting.start.strftime("%Y-%m-%d"),
                 "start_time": meeting.start_time.strftime("%H:%M:%S"),
-                "token": "the token",
                 "recurring_until": meeting.start.strftime("%Y-%m-%d"),
                 "users": [],
                 "weekdays": str(meeting.start.weekday()),


### PR DESCRIPTION
## Purpose

The Jitsi rooms should contain the name of the related Magnify room but still be unique. We need to add this information in the rooms/meetings detail objects returned by the API so the front knows where to connect.

## Proposal

The easiest way is to suffix it with the object's UID which is sure to be unique.
This should not appear in the Jitsi Meet UI as the display is shortened with "..." but we may also be able to hide the Jitsi room from the Jitsi UI when opened inside Magnify.
