### PR TITLE
✨(frontlib) add a form to create a new group

### DIFF
--- a/src/frontend/magnify/src/components/groups/AddGroupForm/AddGroupForm.stories.tsx
+++ b/src/frontend/magnify/src/components/groups/AddGroupForm/AddGroupForm.stories.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import AddGroupForm from './AddGroupForm';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+  title: 'Groups/AddGroupForm',
+  component: AddGroupForm,
+} as ComponentMeta<typeof AddGroupForm>;
+
+const Template: ComponentStory<typeof AddGroupForm> = (args) => <AddGroupForm {...args} />;
+
+// create the template and stories
+export const basicAddGroupForm = Template.bind({});
+basicAddGroupForm.args = {};

--- a/src/frontend/magnify/src/components/groups/AddGroupForm/AddGroupForm.test.tsx
+++ b/src/frontend/magnify/src/components/groups/AddGroupForm/AddGroupForm.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+import userEvent from '@testing-library/user-event';
+import AddGroupForm from './AddGroupForm';
+import { render, screen, waitFor } from '@testing-library/react';
+import { ControllerProvider, MockController } from '../../../controller';
+import createRandomGroup from '../../../factories/group';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+describe('AddGroupForm', () => {
+  it('should render successfully', async () => {
+    const controller = new MockController();
+    const user = userEvent.setup();
+    controller.createGroup.mockResolvedValue(createRandomGroup(5));
+    const onSuccess = jest.fn();
+    const onCancel = jest.fn();
+
+    render(
+      <IntlProvider locale="en">
+        <ControllerProvider controller={controller}>
+          <QueryClientProvider client={new QueryClient()}>
+            <AddGroupForm onSuccess={onSuccess} onCancel={onCancel} />
+          </QueryClientProvider>
+        </ControllerProvider>
+      </IntlProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCancel).toHaveBeenCalled();
+
+    await user.type(screen.getByRole('textbox', { name: 'Name' }), 'Test');
+    await user.click(screen.getByRole('button', { name: 'Add group Test' }));
+    await waitFor(() => expect(controller.createGroup).toHaveBeenCalledWith({ name: 'Test' }));
+    expect(onSuccess).toHaveBeenCalled();
+  });
+});

--- a/src/frontend/magnify/src/components/groups/AddGroupForm/AddGroupForm.tsx
+++ b/src/frontend/magnify/src/components/groups/AddGroupForm/AddGroupForm.tsx
@@ -1,0 +1,81 @@
+import { defineMessages, useIntl } from 'react-intl';
+import React from 'react';
+import { useController } from '../../../controller';
+import { useMutation, useQueryClient } from 'react-query';
+import { Group } from '../../../types/group';
+import useFormState from '../../../hooks/useFormState';
+import validators, { requiredValidator } from '../../../utils/validators';
+import { Box, Button, Heading } from 'grommet';
+import { LoadingButton, TextField } from '../../design-system';
+
+export interface AddGroupFormProps {
+  onSuccess?: () => void;
+  onCancel?: () => void;
+}
+
+const messages = defineMessages({
+  addGroupTitle: {
+    id: 'components.groups.AddGroupForm.addGroupTitle',
+    description: 'Add group heading label',
+    defaultMessage: 'Add group',
+  },
+  addGroupButtonLabel: {
+    id: 'components.groups.AddGroupForm.addGroupButtonLabel',
+    description: 'Add group button label',
+    defaultMessage: 'Add group {name}',
+  },
+  name: {
+    id: 'components.groups.AddGroupForm.name',
+    description: 'Group name label',
+    defaultMessage: 'Name',
+  },
+  cancel: {
+    id: 'components.groups.AddGroupForm.cancel',
+    description: 'Cancel button label',
+    defaultMessage: 'Cancel',
+  },
+});
+
+const AddGroupForm = ({ onSuccess, onCancel }: AddGroupFormProps) => {
+  const intl = useIntl();
+  const controller = useController();
+  const queryClient = useQueryClient();
+  const { mutate, isLoading } = useMutation(controller.createGroup, {
+    onSuccess: (data) => {
+      queryClient.setQueryData('groups', (groups?: Group[]) => [...(groups || []), data]);
+      onSuccess?.();
+    },
+  });
+  const { values, setValue, errors, modified, isValid, isModified } = useFormState(
+    { name: '' },
+    { name: validators(intl, requiredValidator) },
+  );
+
+  return (
+    <Box pad="medium">
+      <Heading level={3}>{intl.formatMessage(messages.addGroupTitle)}</Heading>
+
+      <TextField
+        name="name"
+        label={intl.formatMessage(messages.name)}
+        value={values.name}
+        onChange={(event) => setValue('name', event.target.value)}
+        errors={errors.name}
+        displayErrors={modified.name}
+      />
+
+      <Box margin={{ top: 'small' }} justify="end" direction="row" gap="small">
+        <Button onClick={() => onCancel?.()} label={intl.formatMessage(messages.cancel)} />
+        <LoadingButton
+          primary
+          disabled={!isModified || !isValid}
+          onClick={() => mutate(values)}
+          label={intl.formatMessage(messages.addGroupButtonLabel, { name: values.name })}
+          isLoading={isLoading}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export default AddGroupForm;

--- a/src/frontend/magnify/src/components/groups/AddGroupForm/index.ts
+++ b/src/frontend/magnify/src/components/groups/AddGroupForm/index.ts
@@ -1,0 +1,1 @@
+export { default, AddGroupFormProps } from './AddGroupForm';

--- a/src/frontend/magnify/src/components/groups/GroupsList/GroupsList.tsx
+++ b/src/frontend/magnify/src/components/groups/GroupsList/GroupsList.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import { Layer } from 'grommet';
+import React, { useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { Group } from '../../../types/group';
 import { RowsList } from '../../design-system';
+import AddGroupForm from '../AddGroupForm';
 import GroupRow from '../GroupRow/GroupRow';
 import GroupsHeader from '../GroupsHeader/GroupsHeader';
 
@@ -52,26 +54,36 @@ const messages = defineMessages({
 
 export default function GroupList({ groups }: GroupsListProps) {
   const intl = useIntl();
+  const [openAddGroupForm, setOpenAddGroupForm] = useState(false);
+  const handleOpenGroupForm = () => setOpenAddGroupForm(true);
+  const handleCloseGroupForm = () => setOpenAddGroupForm(false);
 
   return (
-    <RowsList
-      label={messages.numGroupsLabel}
-      addLabel={intl.formatMessage(messages.addGroupButtonLabel)}
-      onAdd={() => {}}
-      actionsLabel={intl.formatMessage(messages.actionGroupLabel)}
-      Header={({ selected, setSelected }) => (
-        <GroupsHeader groupsSelected={selected} setGroupsSelected={setSelected} />
+    <>
+      <RowsList
+        label={messages.numGroupsLabel}
+        addLabel={intl.formatMessage(messages.addGroupButtonLabel)}
+        onAdd={handleOpenGroupForm}
+        actionsLabel={intl.formatMessage(messages.actionGroupLabel)}
+        Header={({ selected, setSelected }) => (
+          <GroupsHeader groupsSelected={selected} setGroupsSelected={setSelected} />
+        )}
+        Row={({ group, selected, onToggle }) => (
+          <GroupRow group={group} selected={selected} onToggle={onToggle} />
+        )}
+        rows={groups.map((group) => ({ group, id: group.id }))}
+        actions={[
+          { label: messages.deleteGroupButtonLabel, onClick: () => {}, disabled: (n) => n === 0 },
+          { label: messages.renameGroupButtonLabel, onClick: () => {}, disabled: (n) => n !== 1 },
+          { label: messages.createRoomButtonLabel, onClick: () => {}, disabled: (n) => n === 0 },
+          { label: messages.createMeetingButtonLabel, onClick: () => {}, disabled: (n) => n === 0 },
+        ]}
+      />
+      {openAddGroupForm && (
+        <Layer onClickOutside={handleCloseGroupForm} onEsc={handleCloseGroupForm}>
+          <AddGroupForm onCancel={handleCloseGroupForm} onSuccess={handleCloseGroupForm} />
+        </Layer>
       )}
-      Row={({ group, selected, onToggle }) => (
-        <GroupRow group={group} selected={selected} onToggle={onToggle} />
-      )}
-      rows={groups.map((group) => ({ group, id: group.id }))}
-      actions={[
-        { label: messages.deleteGroupButtonLabel, onClick: () => {}, disabled: (n) => n === 0 },
-        { label: messages.renameGroupButtonLabel, onClick: () => {}, disabled: (n) => n !== 1 },
-        { label: messages.createRoomButtonLabel, onClick: () => {}, disabled: (n) => n === 0 },
-        { label: messages.createMeetingButtonLabel, onClick: () => {}, disabled: (n) => n === 0 },
-      ]}
-    />
+    </>
   );
 }

--- a/src/frontend/magnify/src/components/groups/index.ts
+++ b/src/frontend/magnify/src/components/groups/index.ts
@@ -4,3 +4,4 @@ export { default as GroupsHeader, GroupsHeaderProps } from './GroupsHeader';
 export { default as MyGroupsBlock } from './MyGroupsBlock';
 export { default as AddUserForm } from './AddUserForm';
 export { default as GroupUserList } from './GroupUserList';
+export { default as AddGroupForm } from './AddGroupForm';

--- a/src/frontend/magnify/src/controller/default.controller.ts
+++ b/src/frontend/magnify/src/controller/default.controller.ts
@@ -5,6 +5,7 @@ import { Room } from '../types/room';
 import { AccessToken, Tokens } from '../types/tokens';
 import Controller, {
   AddGroupsToRoomInput,
+  CreateGroupInput,
   CreateMeetingInput,
   LoginInput,
   SignupInput,
@@ -82,6 +83,9 @@ export default class DefaultController extends Controller {
     throw new Error('Not implemented');
   }
 
+  async createGroup(group: CreateGroupInput): Promise<Group> {
+    throw new Error('Not implemented');
+  }
   async getGroups(): Promise<Group[]> {
     // GET /groups
     throw new Error('Not implemented');

--- a/src/frontend/magnify/src/controller/interface.ts
+++ b/src/frontend/magnify/src/controller/interface.ts
@@ -35,6 +35,9 @@ export interface AddGroupsToRoomInput {
   roomSlug: string;
   groupIds: string[];
 }
+export interface CreateGroupInput {
+  name: string;
+}
 export interface CreateMeetingInput {
   roomSlug?: string;
   name: string;
@@ -89,6 +92,7 @@ export default abstract class Controller {
   abstract deleteUser(id: string): Promise<void>;
 
   // Groups
+  abstract createGroup(group: CreateGroupInput): Promise<Group>;
   abstract getGroups(): Promise<Group[]>;
   abstract getGroup(groupId: string): Promise<Group>;
   abstract addUserToGroup(input: AddUserToGroupInput): Promise<Group>;

--- a/src/frontend/magnify/src/controller/log.controller.ts
+++ b/src/frontend/magnify/src/controller/log.controller.ts
@@ -14,6 +14,7 @@ import { WithToken } from '../types/withToken';
 import Controller, {
   AddGroupsToRoomInput,
   AddUserToGroupInput,
+  CreateGroupInput,
   CreateMeetingInput,
   LoginInput,
   SignupInput,
@@ -220,6 +221,15 @@ export default class LogController extends Controller {
   };
 
   // Groups routes
+  createGroup = async (input: CreateGroupInput) =>
+    promisifiedConsoleLogFactory(
+      this,
+      'createGroup',
+      new MockControllerFunction<CreateGroupInput, Group>().resolveOnDefault({
+        ...createRandomGroup(5),
+        ...input,
+      }),
+    )(input);
   getGroups = promisifiedConsoleLogFactory(
     this,
     'getGroups',

--- a/src/frontend/magnify/src/controller/mock.controller.ts
+++ b/src/frontend/magnify/src/controller/mock.controller.ts
@@ -17,6 +17,7 @@ export default class MockController extends Controller {
   updateUserPassword = jest.fn();
   deleteUser = jest.fn();
 
+  createGroup = jest.fn();
   getGroups = jest.fn();
   getGroup = jest.fn();
   addUserToGroup = jest.fn();


### PR DESCRIPTION

## Purpose

A form to create a new group with it's name. As a v1, we can add users afterward

![Screenshot from 2022-07-12 10-48-30](https://user-images.githubusercontent.com/25184106/178450042-920f7020-7623-4e57-8b57-d7255d6aae63.png)

## Proposal

Nothing unexpected here too. We just complete the onAdd prop
of the row list abstraction to open a popup.

