### PR TITLE
🗑️(frontlib) delete an unused settings link

### DIFF
--- a/src/frontend/magnify/src/components/meetings/MyMeetings/MyMeetings.test.tsx
+++ b/src/frontend/magnify/src/components/meetings/MyMeetings/MyMeetings.test.tsx
@@ -33,6 +33,6 @@ describe('MyMeetings', () => {
     await waitForElementToBeRemoved(() => screen.queryAllByTitle('Loading...'));
 
     // 3) Check the meetings
-    expect(screen.getAllByRole('button', { name: 'Join' }).length).toBe(5);
+    expect(screen.getAllByText('Join').length).toBe(5);
   });
 });

--- a/src/frontend/magnify/src/components/sidebar/MagnifySidebar/MagnifySidebar.tsx
+++ b/src/frontend/magnify/src/components/sidebar/MagnifySidebar/MagnifySidebar.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 
 import SidebarButton, { SidebarButtonProps } from '../SidebarButton';
-import { AvatarSVG, CalEventSVG, GridSVG, GroupSVG, SettingsSVG } from '../../design-system';
+import { AvatarSVG, CalEventSVG, GridSVG, GroupSVG } from '../../design-system';
 import { MarginType } from 'grommet/utils';
 
 export interface MagnifySidebarProps {
@@ -75,11 +75,6 @@ function MagnifySidebar({
         label: intl.formatMessage(messages.sidebarGroupsLabel),
         icon: <GroupSVG />,
         navigateTo: '/groups',
-      },
-      {
-        label: intl.formatMessage(messages.sidebarSettingsLabel),
-        icon: <SettingsSVG />,
-        navigateTo: '/settings',
       },
     ],
   ];


### PR DESCRIPTION
## Purpose

As discussed with the designer, this link was added
without any specific intention of a view, so as long as we
do not have any view, I think we should let this link

![Screenshot from 2022-07-12 11-38-48](https://user-images.githubusercontent.com/25184106/178460589-75078783-b60a-4752-8118-4808e1c5f2f7.png)
![Screenshot from 2022-07-12 11-38-53](https://user-images.githubusercontent.com/25184106/178460592-3d812131-d1f7-4723-87b2-80c5544dc384.png)

