### PR TITLE
🩹(frontlib) fix a layout issue in the meeting config

### DIFF
--- a/src/frontend/magnify/src/components/design-system/Section/Section.tsx
+++ b/src/frontend/magnify/src/components/design-system/Section/Section.tsx
@@ -8,7 +8,7 @@ export interface SectionProps {
 }
 
 const Section = ({ children, title, titleLevel = 3 }: SectionProps) => (
-  <Box background={'white'} round="xsmall" elevation="small" pad="medium">
+  <Box background={'white'} round="xsmall" elevation="small" pad="medium" height="100%">
     {title && (
       <Heading color="brand" level={titleLevel} margin={{ top: '0' }}>
         {title}

--- a/src/frontend/magnify/src/components/rooms/RoomConfig/RoomConfig.tsx
+++ b/src/frontend/magnify/src/components/rooms/RoomConfig/RoomConfig.tsx
@@ -84,8 +84,8 @@ const RoomConfig = ({ roomName }: { roomName: string }) => {
         { name: 'moderationBlock', start: [0, 1], end: mobile ? [1, 1] : [0, 1] },
         { name: 'securityBlock', start: mobile ? [0, 2] : [1, 1], end: mobile ? [1, 2] : [1, 1] },
       ]}
-      columns={['1/2', '1/2']}
-      rows={mobile ? ['1/3', '1/3', '1/3'] : ['1/2', '1/2']}
+      columns={['flex', 'flex']}
+      rows={mobile ? ['auto', 'auto', 'auto'] : ['auto', 'auto']}
       gap="medium"
     >
       <Box gridArea="settingsBlock">


### PR DESCRIPTION
As seen during the demo, options overflow a box on a few browsers. This intends to fix it