### PR TITLE
🐛(frontlib) add missing cache invalidations

### DIFF
--- a/src/frontend/magnify/src/components/rooms/AddGroupToRoomDialog/AddGroupToRoomDialog.tsx
+++ b/src/frontend/magnify/src/components/rooms/AddGroupToRoomDialog/AddGroupToRoomDialog.tsx
@@ -2,7 +2,7 @@ import { defineMessages, useIntl } from 'react-intl';
 import React, { useState } from 'react';
 import { Box, Button, Heading, Layer, Select, Text } from 'grommet';
 import { FormClose } from 'grommet-icons';
-import { useMutation, useQuery } from 'react-query';
+import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 import { useController } from '../../../controller';
 import { Group } from '../../../types/group';
@@ -77,8 +77,12 @@ const AddGroupToRoomDialog = ({ open, onClose, roomSlug }: AddGroupToRoomDialogP
   const intl = useIntl();
   const controller = useController();
   const { data: groups, isLoading: groupsLoading } = useQuery('groups', controller.getGroups);
+  const queryClient = useQueryClient();
   const { mutate, isLoading } = useMutation(controller.addGroupsToRoom, {
-    onSuccess: () => onClose(),
+    onSuccess: (data) => {
+      queryClient.setQueryData(['room', roomSlug], data);
+      onClose();
+    },
   });
   const [selected, setSelected] = useState<number[]>([]);
 

--- a/src/frontend/magnify/src/controller/log.controller.ts
+++ b/src/frontend/magnify/src/controller/log.controller.ts
@@ -294,7 +294,6 @@ export default class LogController extends Controller {
     )(name);
   addGroupsToRoom = async ({ roomSlug, groupIds }: AddGroupsToRoomInput) => {
     const resolvedRoom = createRandomRoom(true);
-    console.log(resolvedRoom, createRandomGroups(groupIds.length));
     resolvedRoom.groups = [...resolvedRoom.groups, ...createRandomGroups(groupIds.length)];
     return await promisifiedConsoleLogFactory(
       this,


### PR DESCRIPTION
## Purpose

After an add request, we need to modify (or refetch) the react query
cache, or the list displayed will not update when the request finish.

## Proposal

This add two missing such cache updates when adding a new group to room
or a new meeting to room
