### PR TITLE
🔍(frontlib) change default title in html template

### DIFF
--- a/src/frontend/demo/public/index.html
+++ b/src/frontend/demo/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Magnify</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
## Purpose

It was still the uggly "React app" title, that is bad for SEO

## Proposal

Just change it to "Magnify"