### PR TITLE
🐛(demo) fix bad route in myMeetings view

### DIFF
--- a/src/frontend/demo/src/views/myMeetings.tsx
+++ b/src/frontend/demo/src/views/myMeetings.tsx
@@ -13,7 +13,7 @@ export default function MeetingsView() {
   const intl = useTranslations();
   return (
     <LayoutWithSidebar title={intl.formatMessage(messages.meetingsViewTitle)}>
-      <MyMeetings baseJitsiUrl="/jitsi" />
+      <MyMeetings baseJitsiUrl="/j" />
     </LayoutWithSidebar>
   );
 }


### PR DESCRIPTION
## Purpose

There was still a bad link in the myMeeting view of the demo,
leading to /jitsi instead of /j. 

## Proposal

Change /jitsi to /j