### PR TITLE
Fix csrf error on admin page

### DIFF
--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -81,7 +81,8 @@ class Base(DRFMixin, MagnifyCoreConfigurationMixin, Configuration):
 
     # Security
     ALLOWED_HOSTS = []
-    SECRET_KEY = values.Value("ThisIsAnExampleKeyForDevPurposeOnly")
+    SECRET_KEY = values.Value(None)
+
     # System check reference:
     # https://docs.djangoproject.com/en/2.2/ref/checks/#security
     SILENCED_SYSTEM_CHECKS = values.ListValue(

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -81,6 +81,7 @@ class Base(DRFMixin, MagnifyCoreConfigurationMixin, Configuration):
 
     # Security
     ALLOWED_HOSTS = []
+    CSRF_TRUSTED_ORIGINS = values.ListValue([])
     SECRET_KEY = values.Value(None)
 
     # System check reference:
@@ -341,7 +342,7 @@ class Development(Base):
 
     DEBUG = True
     ALLOWED_HOSTS = ["*"]
-    CSRF_TRUSTED_ORIGINS = ["http://localhost:8070"]
+    CSRF_TRUSTED_ORIGINS = ["http://localhost:8071"]
     API_URL = values.Value("http://localhost:8071")
 
 


### PR DESCRIPTION
## Purpose

When trying to login to the Django admin site, we get a CSRF 403 error page:

<img src="https://user-images.githubusercontent.com/1427165/191603580-408dd3ff-1cf5-4f1b-9a6b-e44e40125a00.png" />

## Proposal

- Fix `CSRF_TRUSTED_ORIGINS` setting in Development environment
- set the security key via the environment variable and not in the setting file
