### PR TITLE
⬆️(backend) upgrade drf-yasg to version 1.21.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ dev =
     pytest-cov==3.0.0
     pytest-django==4.5.2
     responses==0.20.0
-    drf-yasg==1.20.0
+    drf-yasg==1.21.4
 ci =
     twine==4.0.0
 sandbox =


### PR DESCRIPTION
## Purpose

Since the release of djangorestframework 3.14.0, drf-yasg 1.20.0 does not work properly, so we have to upgrade this package to its latest version to fix this issue.

## Proposal

- [x] Upgrade `drf-yasg` to the latest current version (1.21.4) 
