### PR TITLE
✨(backend) enable cors headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unrealeased]
+
+### Added
+
+- Enable CORS Headers

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -84,6 +84,9 @@ class Base(DRFMixin, MagnifyCoreConfigurationMixin, Configuration):
     CSRF_TRUSTED_ORIGINS = values.ListValue([])
     SECRET_KEY = values.Value(None)
 
+    # CORS headers
+    CORS_ALLOWED_ORIGINS = values.ListValue([], environ_name="CORS_ALLOWED_ORIGINS")
+
     # System check reference:
     # https://docs.djangoproject.com/en/2.2/ref/checks/#security
     SILENCED_SYSTEM_CHECKS = values.ListValue(
@@ -200,6 +203,7 @@ class Base(DRFMixin, MagnifyCoreConfigurationMixin, Configuration):
         "django.middleware.locale.LocaleMiddleware",
         "django.middleware.common.CommonMiddleware",
         "django.middleware.clickjacking.XFrameOptionsMiddleware",
+        "corsheaders.middleware.CorsMiddleware",
         "dockerflow.django.middleware.DockerflowMiddleware",
     )
 
@@ -217,6 +221,7 @@ class Base(DRFMixin, MagnifyCoreConfigurationMixin, Configuration):
         "magnify.apps.core",
         "magnify",
         # Third party apps
+        "corsheaders",
         "dockerflow.django",
         "parler",
         "rest_framework",
@@ -342,6 +347,7 @@ class Development(Base):
 
     DEBUG = True
     ALLOWED_HOSTS = ["*"]
+    CORS_ALLOW_ALL_ORIGINS = True
     CSRF_TRUSTED_ORIGINS = ["http://localhost:8071"]
     API_URL = values.Value("http://localhost:8071")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,6 +67,7 @@ ci =
     twine==4.0.0
 sandbox =
     django-configurations==2.3.2
+    django-cors-headers==3.13.0
     dockerflow==2022.1.0
     factory-boy==3.2.1
     gunicorn==20.1.0


### PR DESCRIPTION
## Purpose

Install django-cors-headers to allow CORS requests from authorized domains on production and from everywhere on development


## Proposal

- [x] Install django-cors-headers
- [x] Setup cors-headers
