### PR TITLE
🐛(api) normalize room names in API calls

### DIFF
--- a/src/magnify/apps/core/api/rooms.py
+++ b/src/magnify/apps/core/api/rooms.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.db.models import F, Q
 from django.http import Http404
 from django.shortcuts import get_object_or_404
+from django.utils.text import slugify
 
 from rest_framework import decorators as drf_decorators
 from rest_framework import mixins, permissions, response, viewsets
@@ -35,7 +36,7 @@ class RoomViewSet(
             uuid.UUID(self.kwargs["pk"])
             filter_kwargs = {"pk": self.kwargs["pk"]}
         except ValueError:
-            filter_kwargs = {"slug": self.kwargs["pk"]}
+            filter_kwargs = {"slug": slugify(self.kwargs["pk"])}
 
         queryset = self.filter_queryset(self.get_queryset())
         obj = get_object_or_404(queryset, **filter_kwargs)
@@ -53,13 +54,12 @@ class RoomViewSet(
         except Http404:
             if not settings.ALLOW_UNREGISTERED_ROOMS:
                 raise
+            slug = slugify(self.kwargs["pk"])
             data = {
                 "id": None,
                 "jitsi": {
-                    "room": self.kwargs["pk"],
-                    "token": utils.generate_token(
-                        request.user, self.kwargs["pk"], is_admin=True
-                    ),
+                    "room": slug,
+                    "token": utils.generate_token(request.user, slug, is_admin=True),
                 },
             }
         else:

--- a/tests/apps/core/test_core_models_meetings_get_occurences.py
+++ b/tests/apps/core/test_core_models_meetings_get_occurences.py
@@ -201,14 +201,14 @@ class OccurencesMeetingsModelsTestCase(TestCase):
         )
 
     def test_models_meetings_get_occurrences_weekly_reset_weekdays(self):
-        """reset weekdays if recurrence not equal to weekly"""
+        """Reset weekdays if recurrence is not weekly"""
         meeting = MeetingFactory(
             start=date(2022, 7, 6),
             recurrence="weekly",
             frequency=1,
             recurring_until=date(2022, 8, 2),
             nb_occurrences=None,
-            meeting.weekdays = "26"
+            weekdays="26",
         )
         self.assertEqual(meeting.weekdays, "26")
         meeting.recurrence = "daily"


### PR DESCRIPTION
## Purpose

Calls to the room detail API endpoint may contain accents and upper case letters in the room name. We want to normalize them to the slug we save in room names.
Said differently "Réunion" and "reunion" should be the same room.

## Proposal

- [x] Call slugify on the room name before looking for a room with this slug
- [x] Add tests to secure this behavior
