### PR TITLE
✨(frontend) set current lang request headers

### DIFF
--- a/src/frontend/magnify/src/i18n/TranslationProvider/TranslationsProvider.tsx
+++ b/src/frontend/magnify/src/i18n/TranslationProvider/TranslationsProvider.tsx
@@ -1,6 +1,7 @@
 import { Box, Spinner } from 'grommet';
 import React, { useEffect, useMemo, useState } from 'react';
 import { IntlProvider, MessageFormatElement, useIntl } from 'react-intl';
+import { getLocaleStorageLang, HttpService } from '../../services';
 import { Maybe } from '../../types/misc';
 import { MAGNIFY_LOCALE_KEY, MagnifyLocales } from '../../utils';
 import { loadLocaleData } from '../Loaders';
@@ -47,9 +48,12 @@ export default function TranslationProvider({
   defaultLocale = MagnifyLocales.EN,
   initTranslation = true,
 }: TranslationProviderProps) {
-  const [currentLocale, setCurrentLocale] = useState(
-    localStorage.getItem(MAGNIFY_LOCALE_KEY) ?? locale,
-  );
+  const [currentLocale, setCurrentLocale] = useState(getLocaleStorageLang(locale));
+
+  useEffect(() => {
+    HttpService.setRequestLanguage(currentLocale);
+  }, [currentLocale]);
+
   const [translations, setTranslations] =
     useState<Maybe<Record<string, string> | Record<string, MessageFormatElement[]>>>(undefined);
 

--- a/src/frontend/magnify/src/services/http/http.service.ts
+++ b/src/frontend/magnify/src/services/http/http.service.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosError } from 'axios';
+
 import { RefreshTokenResponse } from '../../types';
-import { UsersApiRoutes } from '../../utils';
+import { MAGNIFY_LOCALE_KEY, MagnifyLocales, UsersApiRoutes } from '../../utils';
 import { DEFAULT_BASE_API_URL } from '../../utils/constants/config';
 
 export const SESSION_ACCESS_TOKEN_KEY = 'access_token';
@@ -11,6 +12,10 @@ export const getBaseUrl = () => {
 
 export const buildApiUrl = (route: string) => {
   return `${getBaseUrl()}${route}`;
+};
+
+export const getLocaleStorageLang = (defaultLang: string = MagnifyLocales.EN): string => {
+  return localStorage.getItem(MAGNIFY_LOCALE_KEY) ?? defaultLang;
 };
 
 export class HttpService {
@@ -43,16 +48,30 @@ export class HttpService {
     HttpService.setTokens(response.data.access);
     return response.data.access;
   }
+
+  public static setRequestLanguage(lang: string): void {
+    MagnifyApi.defaults.headers.common['Content-Language'] = lang;
+    MagnifyApi.defaults.headers.common['Accept-Language'] = lang;
+    MagnifyAuthApi.defaults.headers.common['Content-Language'] = lang;
+    MagnifyAuthApi.defaults.headers.common['Accept-Language'] = lang;
+  }
 }
 
 export const MagnifyAuthApi = axios.create({
   baseURL: getBaseUrl(),
+  headers: {
+    'Content-type': 'application/json',
+    'Accept-Language': getLocaleStorageLang(),
+    'Content-Language': getLocaleStorageLang(),
+  },
 });
 
 export const MagnifyApi = axios.create({
   baseURL: getBaseUrl(),
   headers: {
     'Content-type': 'application/json',
+    'Accept-Language': getLocaleStorageLang(),
+    'Content-Language': getLocaleStorageLang(),
   },
 });
 


### PR DESCRIPTION
## Purpose

Currently, the messages sent by the back are conditioned by the language of the browser. To make the messages sent by the back correspond to the language chosen by the user and not to the language of the browser we update the headers

## Proposal


- [x] init headers with the locale in localStorage
- [x] update headers when we change user locale 
