### PR TITLE
:sparkles:(frontend) display message when the list of rooms is empty

### DIFF
--- a/src/frontend/magnify/src/components/rooms/MyRooms/MyRooms.tsx
+++ b/src/frontend/magnify/src/components/rooms/MyRooms/MyRooms.tsx
@@ -13,6 +13,11 @@ const messages = defineMessages({
     defaultMessage: 'List of rooms',
     description: 'Label for the button to register a new room',
   },
+  emptyRoomListMessage: {
+    id: 'components.rooms.myRooms.emptyRoomListMessage',
+    defaultMessage: 'No room was created yet. Click on the button " + Room" to create one.',
+    description: 'The message to display when there are no rooms.',
+  }
 });
 
 export interface MyRoomsProps {
@@ -34,9 +39,12 @@ const MyRooms = ({ baseJitsiUrl, rooms = [], ...props }: MyRoomsProps) => {
           <RegisterRoom />
         </div>
       </Box>
-      {rooms.map((room) => {
-        return <RoomRow key={room.slug} baseJitsiUrl={baseJitsiUrl} room={room} />;
-      })}
+      {rooms?.length > 0 
+        ? rooms.map((room) => {
+            return <RoomRow key={room.slug} baseJitsiUrl={baseJitsiUrl} room={room} />;
+          }) 
+        : intl.formatMessage(messages.emptyRoomListMessage)
+      }
     </Card>
   );
 };

--- a/src/frontend/magnify/src/components/rooms/MyRooms/MyRooms.tsx
+++ b/src/frontend/magnify/src/components/rooms/MyRooms/MyRooms.tsx
@@ -17,7 +17,7 @@ const messages = defineMessages({
     id: 'components.rooms.myRooms.emptyRoomListMessage',
     defaultMessage: 'No room was created yet. Click on the button " + Room" to create one.',
     description: 'The message to display when there are no rooms.',
-  }
+  },
 });
 
 export interface MyRoomsProps {
@@ -39,12 +39,11 @@ const MyRooms = ({ baseJitsiUrl, rooms = [], ...props }: MyRoomsProps) => {
           <RegisterRoom />
         </div>
       </Box>
-      {rooms?.length > 0 
+      {rooms?.length > 0
         ? rooms.map((room) => {
             return <RoomRow key={room.slug} baseJitsiUrl={baseJitsiUrl} room={room} />;
-          }) 
-        : intl.formatMessage(messages.emptyRoomListMessage)
-      }
+          })
+        : intl.formatMessage(messages.emptyRoomListMessage)}
     </Card>
   );
 };


### PR DESCRIPTION
## Purpose

When the user had not yet created a room, no message was displayed to indicate this fact and the section containing the list of rooms was left blank.

## Proposal

- [] Add a small message indicating that no room was created yet to inform the user of that fact in the section which will later contain the list of rooms
