### PR TITLE
✨ (frontend) display message when the list of rooms is empty

### DIFF
--- a/src/frontend/magnify/src/components/rooms/MyRooms/MyRooms.test.tsx
+++ b/src/frontend/magnify/src/components/rooms/MyRooms/MyRooms.test.tsx
@@ -1,3 +1,4 @@
+import { M } from 'msw/lib/glossary-dc3fd077';
 import React from 'react';
 import createRandomRoom from '../../../factories/rooms';
 import { render, screen } from '../../../utils/test-utils';
@@ -10,5 +11,11 @@ describe('MyRooms', () => {
 
     // 3) Check the rooms
     expect(screen.getAllByRole('button', { name: 'Join' }).length).toBe(1);
+  });
+  it('should display message when rooms list is emty', async () => {
+    render(<MyRooms baseJitsiUrl="" rooms={[]} />);
+    await screen.findByText(
+      'No room was created yet. Click on the button " + Room" to create one.',
+    );
   });
 });

--- a/src/frontend/magnify/src/components/rooms/MyRooms/MyRooms.tsx
+++ b/src/frontend/magnify/src/components/rooms/MyRooms/MyRooms.tsx
@@ -1,4 +1,4 @@
-import { Box, Card } from 'grommet';
+import { Box, Card, Text } from 'grommet';
 import { Heading } from 'grommet/components';
 import React from 'react';
 import { defineMessages } from 'react-intl';
@@ -12,6 +12,11 @@ const messages = defineMessages({
     id: 'components.rooms.myRooms.myRoomCardTitle',
     defaultMessage: 'List of rooms',
     description: 'Label for the button to register a new room',
+  },
+  emptyRoomListMessage: {
+    id: 'components.rooms.myRooms.emptyRoomListMessage',
+    defaultMessage: 'No room was created yet. Click on the button " + Room" to create one.',
+    description: 'The message to display when there are no rooms.',
   },
 });
 
@@ -34,9 +39,15 @@ const MyRooms = ({ baseJitsiUrl, rooms = [], ...props }: MyRoomsProps) => {
           <RegisterRoom />
         </div>
       </Box>
-      {rooms.map((room) => {
-        return <RoomRow key={room.slug} baseJitsiUrl={baseJitsiUrl} room={room} />;
-      })}
+      {rooms?.length > 0 ? (
+        rooms.map((room) => {
+          return <RoomRow key={room.slug} baseJitsiUrl={baseJitsiUrl} room={room} />;
+        })
+      ) : (
+        <Text alignSelf="center" size="small">
+          {intl.formatMessage(messages.emptyRoomListMessage)}
+        </Text>
+      )}
     </Card>
   );
 };


### PR DESCRIPTION
## Purpose

When the user had not yet created a room, no message was displayed to indicate this fact and the section containing the list of rooms was left blank.

## Proposal

- [x] Add a small message indicating that no room was created yet to inform the user of that fact in the section which will later contain the list of rooms