### PR TITLE
Update models.py

### DIFF
--- a/src/magnify/apps/core/models.py
+++ b/src/magnify/apps/core/models.py
@@ -430,7 +430,22 @@ class Meeting(BaseModel):
             self.reset_recurrence()
 
         super().save(*args, **kwargs)
-
+ 
+    def next_occurrence_from_today(self):
+        """
+        Returns the next occurrence of the meeting from today.
+        """
+        if self.start == timezone.now().date():
+            start_datetime = dt.combine(self.start, self.start_time)
+            start_datetime = timezone.make_aware(start_datetime)
+            start_datetime = start_datetime + self.expected_duration
+            if start_datetime > timezone.now():
+                return self.start
+        next_one = self.next_occurrence(self.start)
+        while next_one < timezone.now().date():
+            next_one = self.next_occurrence(next_one)
+        return next_one
+ 
     def next_occurrence(self, current_date):
         """
         This method takes as assumption that the current date passed in argument


### PR DESCRIPTION
Add method to get the next occurrence of meeting from today.

## Purpose

We need to know when is the next occurrence of a meeting from today. The method next_occurrence need of occurrence date of a meeting and except the start date we don't any one. The get occurrence method need a end date and we don't have one except the recurring until date. 


## Proposal

We don't know if it's a good method but we want to purpose you this solution to have your feedback about that. The method check if today is an occurrence of meeting and if not parse next_occurence meeting until find one
