### PR TITLE
♻️(api) show room users and groups to members on room detail endpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,8 @@ aliases:
     restore_cache:
       name: Restore node_modules cache
       keys:
-        - v10-front-dependencies-{{ checksum "~/fun/src/frontend/yarn.lock" }}
-        - v10-front-dependencies-
+        - v11-front-dependencies-{{ checksum "~/fun/src/frontend/yarn.lock" }}
+        - v11-front-dependencies-
 
 jobs:
   # Git jobs
@@ -494,7 +494,7 @@ jobs:
             - ./node_modules
             - ./magnify/node_modules
             - ./demo/node_modules
-          key: v10-front-dependencies-{{ checksum "yarn.lock" }}
+          key: v11-front-dependencies-{{ checksum "yarn.lock" }}
 
   lint-front:
     docker:

--- a/src/magnify/apps/core/api/rooms.py
+++ b/src/magnify/apps/core/api/rooms.py
@@ -95,7 +95,7 @@ class RoomViewSet(
         """Set the current user as owner of the newly created room."""
         room = serializer.save()
         models.RoomUserAccess.objects.create(
-            room=room, user=self.request.user, role=models.UserRoleChoices.OWNER
+            room=room, user=self.request.user, role=models.RoleChoices.OWNER
         )
 
     @drf_decorators.action(
@@ -184,8 +184,8 @@ class RoomAccessListModelMixin:
                 Q(
                     room__user_accesses__user=user,
                     room__user_accesses__role__in=[
-                        models.UserRoleChoices.ADMIN,
-                        models.UserRoleChoices.OWNER,
+                        models.RoleChoices.ADMIN,
+                        models.RoleChoices.OWNER,
                     ],
                 )
                 | Q(

--- a/src/magnify/apps/core/factories.py
+++ b/src/magnify/apps/core/factories.py
@@ -128,7 +128,7 @@ class MeetingUserFactory(factory.django.DjangoModelFactory):
 
     meeting = factory.SubFactory(MeetingFactory)
     user = factory.SubFactory(UserFactory)
-    role = fuzzy.FuzzyChoice(core_models.UserRoleChoices.values)
+    role = fuzzy.FuzzyChoice(core_models.RoleChoices.values)
 
 
 class MeetingGroupAccessFactory(factory.django.DjangoModelFactory):
@@ -187,7 +187,7 @@ class RoomUserAccessFactory(factory.django.DjangoModelFactory):
 
     room = factory.SubFactory(RoomFactory)
     user = factory.SubFactory(UserFactory)
-    role = fuzzy.FuzzyChoice(core_models.UserRoleChoices.values)
+    role = fuzzy.FuzzyChoice(core_models.RoleChoices.values)
 
 
 class RoomGroupAccessFactory(factory.django.DjangoModelFactory):

--- a/tests/apps/core/test_core_api_room_user_access.py
+++ b/tests/apps/core/test_core_api_room_user_access.py
@@ -15,7 +15,7 @@ from magnify.apps.core.factories import (
     RoomUserAccessFactory,
     UserFactory,
 )
-from magnify.apps.core.models import RoomUserAccess, UserRoleChoices
+from magnify.apps.core.models import RoleChoices, RoomUserAccess
 from magnify.apps.core.serializers import RoomUserAccessSerializer
 
 # pylint: disable=too-many-public-methods, too-many-lines
@@ -287,9 +287,9 @@ class RoomUserAccessesApiTestCase(APITestCase):
 
         for is_public in [True, False]:
             room = RoomFactory(is_public=is_public)
-            self.assertEqual(len(UserRoleChoices.choices), 3)
+            self.assertEqual(len(RoleChoices.choices), 3)
 
-            for role, _name in UserRoleChoices.choices:
+            for role, _name in RoleChoices.choices:
                 access = RoomUserAccessFactory(room=room, role=role)
                 response = self.client.get(
                     f"/api/room-user-accesses/{access.id!s}/",
@@ -316,9 +316,9 @@ class RoomUserAccessesApiTestCase(APITestCase):
                 users=[(user, "member")],
                 groups=[(group, "member")],
             )
-            self.assertEqual(len(UserRoleChoices.choices), 3)
+            self.assertEqual(len(RoleChoices.choices), 3)
 
-            for role, _name in UserRoleChoices.choices:
+            for role, _name in RoleChoices.choices:
                 access = RoomUserAccessFactory(room=room, role=role)
                 response = self.client.get(
                     f"/api/room-user-accesses/{access.id!s}/",
@@ -340,9 +340,9 @@ class RoomUserAccessesApiTestCase(APITestCase):
 
         for is_public in [True, False]:
             room = RoomFactory(is_public=is_public, users=[(user, "administrator")])
-            self.assertEqual(len(UserRoleChoices.choices), 3)
+            self.assertEqual(len(RoleChoices.choices), 3)
 
-            for role, _name in UserRoleChoices.choices:
+            for role, _name in RoleChoices.choices:
                 access = RoomUserAccessFactory(room=room, role=role)
                 response = self.client.get(
                     f"/api/room-user-accesses/{access.id!s}/",
@@ -373,9 +373,9 @@ class RoomUserAccessesApiTestCase(APITestCase):
 
         for is_public in [True, False]:
             room = RoomFactory(is_public=is_public, groups=[(group, "administrator")])
-            self.assertEqual(len(UserRoleChoices.choices), 3)
+            self.assertEqual(len(RoleChoices.choices), 3)
 
-            for role, _name in UserRoleChoices.choices:
+            for role, _name in RoleChoices.choices:
                 access = RoomUserAccessFactory(room=room, role=role)
                 response = self.client.get(
                     f"/api/room-user-accesses/{access.id!s}/",
@@ -403,9 +403,9 @@ class RoomUserAccessesApiTestCase(APITestCase):
 
         for is_public in [True, False]:
             room = RoomFactory(is_public=is_public, users=[(user, "owner")])
-            self.assertEqual(len(UserRoleChoices.choices), 3)
+            self.assertEqual(len(RoleChoices.choices), 3)
 
-            for role, _name in UserRoleChoices.choices:
+            for role, _name in RoleChoices.choices:
                 access = RoomUserAccessFactory(room=room, role=role)
                 response = self.client.get(
                     f"/api/room-user-accesses/{access.id!s}/",
@@ -611,7 +611,7 @@ class RoomUserAccessesApiTestCase(APITestCase):
             "id": uuid4(),
             "room": RoomFactory().id,
             "user": UserFactory().id,
-            "role": random.choice(UserRoleChoices.choices)[0],
+            "role": random.choice(RoleChoices.choices)[0],
         }
 
         for field, value in new_values.items():
@@ -636,7 +636,7 @@ class RoomUserAccessesApiTestCase(APITestCase):
             "id": uuid4(),
             "room": RoomFactory(users=[(user, "member")]).id,
             "user": UserFactory().id,
-            "role": random.choice(UserRoleChoices.choices)[0],
+            "role": random.choice(RoleChoices.choices)[0],
         }
 
         for field, value in new_values.items():
@@ -667,7 +667,7 @@ class RoomUserAccessesApiTestCase(APITestCase):
             "id": uuid4(),
             "room": RoomFactory(users=[(user, "member")]).id,
             "user": UserFactory().id,
-            "role": random.choice(UserRoleChoices.choices)[0],
+            "role": random.choice(RoleChoices.choices)[0],
         }
 
         for field, value in new_values.items():
@@ -775,7 +775,7 @@ class RoomUserAccessesApiTestCase(APITestCase):
             "id": uuid4(),
             "room": RoomFactory(users=[(user, "administrator")]).id,
             "user": UserFactory().id,
-            "role": random.choice(UserRoleChoices.choices)[0],
+            "role": random.choice(RoleChoices.choices)[0],
         }
 
         for field, value in new_values.items():
@@ -845,7 +845,7 @@ class RoomUserAccessesApiTestCase(APITestCase):
             "id": uuid4(),
             "room": RoomFactory(users=[(user, "administrator")]).id,
             "user": UserFactory().id,
-            "role": random.choice(UserRoleChoices.choices)[0],
+            "role": random.choice(RoleChoices.choices)[0],
         }
 
         for field, value in new_values.items():
@@ -882,7 +882,7 @@ class RoomUserAccessesApiTestCase(APITestCase):
             "id": uuid4(),
             "room": RoomFactory(users=[(user, "administrator")]).id,
             "user": UserFactory().id,
-            "role": random.choice(UserRoleChoices.choices)[0],
+            "role": random.choice(RoleChoices.choices)[0],
         }
 
         for field, value in new_values.items():

--- a/tests/apps/core/test_core_models_meeting_user_access.py
+++ b/tests/apps/core/test_core_models_meeting_user_access.py
@@ -24,7 +24,7 @@ class MeetingUserAccessModelsTestCase(TestCase):
         access = MeetingUserFactory(
             meeting__name="my meeting", user__name="François", role="administrator"
         )
-        self.assertEqual(str(access), "My meeting / François (Admin)")
+        self.assertEqual(str(access), "My meeting / François (Administrator)")
 
     def test_models_meeting_user_access_str_owner(self):
         """The str representation for an admin user should include the mention."""

--- a/tests/apps/core/test_core_models_room_user_access.py
+++ b/tests/apps/core/test_core_models_room_user_access.py
@@ -24,7 +24,7 @@ class RoomUserAccessesModelsTestCase(TestCase):
         access = RoomUserAccessFactory(
             room__name="my room", user__name="François", role="administrator"
         )
-        self.assertEqual(str(access), "My room / François (Admin)")
+        self.assertEqual(str(access), "My room / François (Administrator)")
 
     def test_models_room_user_accesses_str_owner(self):
         """The str representation for an admin user should include the mention."""


### PR DESCRIPTION
## Purpose

Only administrators and owners of a room could see its related users and groups. We think all members of a room should see them.

## Proposal

Add "users" and "groups" fields to the payload returned on the room detail endpoint for a room's members.

I took the opportunity to refactor access rights methods and optimize the number of database query they generate.
