### PR TITLE
🐛(frontend) fix handle error register room form

### DIFF
--- a/src/frontend/magnify/packages/components/src/components/rooms/RegisterRoomForm/RegisterRoomForm.tsx
+++ b/src/frontend/magnify/packages/components/src/components/rooms/RegisterRoomForm/RegisterRoomForm.tsx
@@ -59,9 +59,6 @@ export const RegisterRoomForm = ({ onSuccess }: RegisterRoomFormProps) => {
       });
       onSuccess(newRoom);
     },
-    onError: (error) => {
-      errors.onError(error);
-    },
   });
 
   const initialValues: RegisterRoomFormValues = useMemo(
@@ -80,6 +77,8 @@ export const RegisterRoomForm = ({ onSuccess }: RegisterRoomFormProps) => {
         const formErrors = error?.response?.data as Maybe<FormErrors>;
         if (formErrors?.slug) {
           actions.setFieldError('name', formErrors.slug.join(','));
+        } else {
+          errors.onError(error);
         }
       },
     });


### PR DESCRIPTION
## Purpose

The error modal appears even when it's an error handled by react. Like for example a room that already exists

## Proposal

Show modal only when it's not a known error
