### PR TITLE
🔧(magnify-site) disable treeshaking for production build

### DIFF
--- a/src/frontend/magnify/apps/magnify-site/vite.config.ts
+++ b/src/frontend/magnify/apps/magnify-site/vite.config.ts
@@ -3,6 +3,15 @@ import { defineConfig } from 'vitest/config';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      // grommet declares in its package.json a sideEffects attribute which targets
+      // ThemeContext module. For still unknown reason, this module is removed during
+      // the rollup tree shaking. As a workaround, we disable the tree shaking.
+      // The drawback is that the bundle size is bigger (about 9%).
+      treeshake: false,
+    },
+  },
   server: {
     host: true,
     port: 3200,


### PR DESCRIPTION
## Purpose

Currently the production build does not work as rollup treeshake remove from bundle the ThemeContext module provided by grommet. For now, the only workaround, we found is to disable treeshake.


## Proposal

- [x] Disable rollup treeshake to build magnify-site for production
