### PR TITLE
✨(users) allow deactivating the creation of users via the API

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -200,6 +200,18 @@ generate a Jitsi JWT token to any user visiting any room that is not registered.
   * False: 'no', 'n', 'false', '0', '' (empty string)
 - Required: No
 - Default: True
+- Example: `false`
+
+#### MAGNIFY_ALLOW_API_USER_CREATE
+
+Whether users can be created via the API. When not allowed, user handling is delegated to
+an external tool and Magnify creates users on-the-fly based on OIDC tokens received.
+
+- Type: Boolean as string
+  * True: 'yes', 'y', 'true', '1'
+  * False: 'no', 'n', 'false', '0', '' (empty string)
+- Required: No
+- Default: False
 - Example: `true`
 
 #### MAGNIFY_JWT_USER_DEVICE_AUDIENCES

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -137,6 +137,9 @@ class Base(MagnifyCoreConfigurationMixin, Configuration):
     ALLOW_UNREGISTERED_ROOMS = values.BooleanValue(
         True, environ_name="MAGNIFY_ALLOW_UNREGISTERED_ROOMS", environ_prefix=None
     )
+    ALLOW_API_USER_CREATE = values.BooleanValue(
+        False, environ_name="MAGNIFY_ALLOW_API_USER_CREATE", environ_prefix=None
+    )
 
     # Database
     DATABASES = {

--- a/src/magnify/apps/core/permissions.py
+++ b/src/magnify/apps/core/permissions.py
@@ -1,4 +1,6 @@
 """Permission handlers for Magnify's core app."""
+from django.conf import settings
+
 from rest_framework import permissions
 
 from .models import RoleChoices
@@ -37,6 +39,9 @@ class IsSelf(permissions.BasePermission):
         Only if the user is logged-in and sts and the current logged in user is one
         of its administrator.
         """
+        if view.action == "create":
+            return getattr(settings, "ALLOW_API_USER_CREATE", False)
+
         if view.action in ["list", "retrieve"]:
             return request.user.is_authenticated
 


### PR DESCRIPTION

## Purpose

When relying on Keycloak or another external store of users, we want to deactivate user creation on the API and let Magnify create them on-the-fly via OIDC tokens.

## Proposal

Add a new setting to allow deactivating user creation via the API
