### PR TITLE
Conf/npm publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -489,6 +489,7 @@ jobs:
           paths:
             - src/frontend/magnify/apps/magnify-site/i18n/frontend.json
             - src/frontend/magnify/packages/components/i18n/frontend.json
+            - src/frontend/magnify/packages/components/dist
       - save_cache:
           paths:
             - ./node_modules
@@ -543,21 +544,23 @@ jobs:
 
   # Publishing to npm requires that you have define the NPM_TOKEN secret
   # environment variables in CircleCI UI (with your PyPI credentials)
-#  npm:
-#    docker:
-#      - image: cimg/node:16.15
-#        auth:
-#          username: $DOCKER_USER
-#          password: $DOCKER_PASS
-#    working_directory: ~/fun
-#    steps:
-#      - *checkout_fun
-#      - run:
-#          name: Authenticate with registry
-#          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/fun/.npmrc
-#      - run:
-#          name: Publish package
-#          command: npm publish src/frontend/magnify/
+  npm:
+    docker:
+      - image: cimg/node:16.15
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+    working_directory: ~/fun
+    steps:
+      - *checkout_fun
+      - attach_workspace:
+          at: ~/fun
+      - run:
+          name: Authenticate with registry
+          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/fun/.npmrc
+      - run:
+          name: Publish @openfun/magnify-components package
+          command: npm publish src/frontend/magnify/packages/components
 
   # ---- DockerHub publication job ----
   hub:
@@ -767,17 +770,18 @@ workflows:
       # NPM publication.
       #
       # Publish frontend package to NPM only if all build, lint and test jobs
-      # succeed and it has been tagged with a tag starting with the letter v
-#      - npm:
-#          requires:
-#            - check-versions
-#            - lint-front
-#            - test-front
-#          filters:
-#            branches:
-#              ignore: /.*/
-#            tags:
-#              only: /^v.*/
+      # succeed, and it has been tagged with a tag starting with the letter v
+      - npm:
+          requires:
+            - check-versions
+            - build-front
+            - lint-front
+            - test-front
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
 
       # DockerHub publication.
       #

--- a/src/frontend/magnify/packages/components/README.md
+++ b/src/frontend/magnify/packages/components/README.md
@@ -1,0 +1,8 @@
+# @openfun/magnify-components
+
+[![CircleCI](https://circleci.com/gh/openfun/jitsi-magnify/tree/main.svg?style=svg)](https://circleci.com/gh/openfun/jitsi-magnify/tree/main)
+[![npm version](https://badge.fury.io/js/@openfun%2Fmagnify-components.svg)](https://badge.fury.io/js/@openfun%2Fmagnify-components)
+
+## Purpose
+This package contains a set of React components and network modules that can be used to
+build a custom [jitsi-magnify](https://github.com/openfun/jitsi-magnify) application.

--- a/src/frontend/magnify/packages/components/package.json
+++ b/src/frontend/magnify/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfun/magnify-components",
-  "private": true,
+  "private": false,
   "version": "0.1.0",
   "type": "module",
   "module": "./dist/index.js",
@@ -13,6 +13,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "dev": "tsc && vite build --watch",
     "build": "tsc && vite build",
@@ -29,11 +32,10 @@
     "format:write": "prettier --write src"
   },
   "dependencies": {
-    "@magnify/typescript-configs": "*",
-    "eslint-config-custom": "*",
     "keycloak-js": "20.0.1"
   },
   "peerDependencies": {
+    "@fontsource/roboto": "4.5.8",
     "@jitsi/react-sdk": "1.1.0",
     "@tanstack/react-query": "4.7.2",
     "@types/styled-components": "5.1.25",
@@ -48,14 +50,14 @@
     "react-router-dom": "6.3.0",
     "styled-components": "5.3.5",
     "validator": "13.7.0",
-    "yup": "0.32.11",
-    "@fontsource/roboto": "4.5.8"
+    "yup": "0.32.11"
   },
   "devDependencies": {
     "@bbbtech/storybook-formik": "2.5.0",
     "@faker-js/faker": "7.3.0",
     "@formatjs/cli": "5.0.2",
     "@formatjs/intl-relativetimeformat": "11.0.2",
+    "@magnify/typescript-configs": "*",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@storybook/addon-actions": "6.5.13",
     "@storybook/addon-essentials": "6.5.13",


### PR DESCRIPTION
## Purpose

Restore `npm` ci job to publish the `@openfun/magnify-components`


## Proposal

- [x] Configure project to be able to publish `@openfun/magnify-components` package 
- [x] Add a basic README to this package to prevent to have a blank description on npm
