### PR TITLE
🐛(core) base room.jitsi_name only on room.slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Enable CORS Headers
 - Add Multilingual
 - Add default language management with LANGUAGE_CODE
+
+### Fixed
+
+- Use only room.slug to get room.jitsi_name

--- a/src/magnify/apps/core/models.py
+++ b/src/magnify/apps/core/models.py
@@ -402,7 +402,7 @@ class Room(Resource):
     @property
     def jitsi_name(self):
         """The name used for the room in Jitsi."""
-        return f"{self.slug:s}-{self.id!s}"
+        return self.slug
 
 
 class Meeting(BaseModel):

--- a/tests/apps/core/test_core_api_rooms.py
+++ b/tests/apps/core/test_core_api_rooms.py
@@ -47,7 +47,7 @@ class RoomsApiTestCase(APITestCase):
                 "is_administrable": False,
                 "is_public": True,
                 "jitsi": {
-                    "room": f"{room_public.slug:s}-{room_public.id!s}",
+                    "room": room_public.slug,
                     "token": "the token",
                 },
                 "name": room_public.name,
@@ -276,7 +276,7 @@ class RoomsApiTestCase(APITestCase):
                 "is_administrable": False,
                 "is_public": True,
                 "jitsi": {
-                    "room": f"{room.slug:s}-{room.id!s}",
+                    "room": room.slug,
                     "token": "the token",
                 },
                 "name": room.name,
@@ -311,16 +311,14 @@ class RoomsApiTestCase(APITestCase):
                 "is_administrable": False,
                 "is_public": True,
                 "jitsi": {
-                    "room": f"{room.slug:s}-{room.id!s}",
+                    "room": room.slug,
                     "token": "the token",
                 },
                 "name": room.name,
                 "slug": room.slug,
             },
         )
-        mock_token.assert_called_once_with(
-            user, f"{room.slug:s}-{room.id!s}", is_admin=False
-        )
+        mock_token.assert_called_once_with(user, room.slug, is_admin=False)
 
     def test_api_rooms_retrieve_authenticated(self):
         """
@@ -425,16 +423,14 @@ class RoomsApiTestCase(APITestCase):
                 "is_administrable": False,
                 "is_public": room.is_public,
                 "jitsi": {
-                    "room": f"{room.slug:s}-{room.id!s}",
+                    "room": room.slug,
                     "token": "the token",
                 },
                 "name": room.name,
                 "slug": room.slug,
             },
         )
-        mock_token.assert_called_once_with(
-            user, f"{room.slug:s}-{room.id!s}", is_admin=False
-        )
+        mock_token.assert_called_once_with(user, room.slug, is_admin=False)
 
     @mock.patch(
         "magnify.apps.core.serializers.rooms.generate_token", return_value="the token"
@@ -513,16 +509,14 @@ class RoomsApiTestCase(APITestCase):
                 "is_administrable": False,
                 "is_public": room.is_public,
                 "jitsi": {
-                    "room": f"{room.slug:s}-{room.id!s}",
+                    "room": room.slug,
                     "token": "the token",
                 },
                 "name": room.name,
                 "slug": room.slug,
             },
         )
-        mock_token.assert_called_once_with(
-            user, f"{room.slug:s}-{room.id!s}", is_admin=False
-        )
+        mock_token.assert_called_once_with(user, room.slug, is_admin=False)
 
     @mock.patch(
         "magnify.apps.core.serializers.rooms.generate_token", return_value="the token"
@@ -605,16 +599,14 @@ class RoomsApiTestCase(APITestCase):
                 "is_public": room.is_public,
                 "configuration": {},
                 "jitsi": {
-                    "room": f"{room.slug:s}-{room.id!s}",
+                    "room": room.slug,
                     "token": "the token",
                 },
                 "name": room.name,
                 "slug": room.slug,
             },
         )
-        mock_token.assert_called_once_with(
-            user, f"{room.slug:s}-{room.id!s}", is_admin=True
-        )
+        mock_token.assert_called_once_with(user, room.slug, is_admin=True)
 
     @mock.patch(
         "magnify.apps.core.serializers.rooms.generate_token", return_value="the token"
@@ -673,16 +665,14 @@ class RoomsApiTestCase(APITestCase):
                 "is_public": room.is_public,
                 "configuration": {},
                 "jitsi": {
-                    "room": f"{room.slug:s}-{room.id!s}",
+                    "room": room.slug,
                     "token": "the token",
                 },
                 "name": room.name,
                 "slug": room.slug,
             },
         )
-        mock_token.assert_called_once_with(
-            administrator, f"{room.slug:s}-{room.id!s}", is_admin=True
-        )
+        mock_token.assert_called_once_with(administrator, room.slug, is_admin=True)
 
     def test_api_rooms_create_anonymous(self):
         """Anonymous users should not be allowed to create rooms."""


### PR DESCRIPTION
## Purpose

Currently, the room.jitsi_name bound into the jwt token generated to be authenticated on the jitsi instance is not the same as the real jitsi room the user tries to access. It appears this difference can prevent a user to enter into a jitsi meeting according the jitsi server configuration. As the slug of a room is unique, we can safely use only this field to build the room.jitsi_name.

In this way real room name and room name bound to the jwt token are the same.


## Proposal

- [x] Build room.jitsi_name property only from its slug
- [x] Update test suites
