### PR TITLE
Allow setting default language

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -59,6 +59,19 @@ See [Django documentation][secret-key] for more information about this setting.
 - Default: None
 - Example: `13f1ef@^xqmc=pjv1(!hko7li2a#!f_vuv%cq8$sr2363yn^3!`
 
+#### DJANGO_LANGUAGE_CODE
+
+A string to set the default language code for this installation. This should be in standard
+language ID format. For example, U.S. English is "en-us".
+
+At the moment, Magnify does not allow to override Django's `LANGUAGES` setting so the
+`LANGUAGE_CODE` setting can only be set to `en` or `fr`.
+
+- Type: String [en|fr]
+- Required: No
+- Default: `en`
+- Example: `fr`
+
 #### DJANGO_CSRF_TRUSTED_ORIGINS
 
 A list of trusted origins for unsafe requests (e.g. POST).

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -290,7 +290,7 @@ class Base(MagnifyCoreConfigurationMixin, Configuration):
 
     # Languages
     # - Django
-    LANGUAGE_CODE = "en"
+    LANGUAGE_CODE = values.Value("en")
 
     # Careful! Languages should be ordered by priority, as this tuple is used to get
     # fallback/default languages throughout the app.

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ include_package_data = True
 # `matchPackageNames` (in the "ignored python dependencies" group) within
 # renovate.json file at the root of this repository
 install_requires =
-    Django
+    Django<4.2 # waiting for django-configurations>2.4
     djangorestframework
     django-parler>=2.0.1
     django-redis>=4.11.0


### PR DESCRIPTION
## Purpose

We want to allow setting the default language via environment variables.

## Proposal

Add a Django Configuration value for the `LANGUAGE_CODE` setting and update the docs.