### PR TITLE
🐛(frontend) use jitsi name from back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,6 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Enable CORS Headers
 - Add Multilingual
-- Add default language management with LANGUAGE_CODE
+- Add default language management with LANGUAGE_CODE 
+- Use the backend's jitsi name to match the JWT token and set the subject to 
+the actual room name.

--- a/src/frontend/magnify/apps/magnify-site/src/views/rooms/jitsi/index.tsx
+++ b/src/frontend/magnify/apps/magnify-site/src/views/rooms/jitsi/index.tsx
@@ -39,7 +39,8 @@ export function RoomsJitsiView() {
           <MagnifyMeeting
             configuration={room?.configuration ?? defaultConfiguration}
             jwt={room.jitsi.token}
-            roomName={room.name ?? room.jitsi.room}
+            roomDisplayName={room.name}
+            roomName={room.jitsi.room}
           />
         </Box>
       )}

--- a/src/frontend/magnify/packages/components/src/components/jitsi/MagnifyMeeting/index.tsx
+++ b/src/frontend/magnify/packages/components/src/components/jitsi/MagnifyMeeting/index.tsx
@@ -13,6 +13,7 @@ import { DEFAULT_JITSI_DOMAIN } from '../../../utils/settings';
 export interface MagnifyMeetingProps {
   roomSlug?: string;
   roomName: string;
+  roomDisplayName: string;
   meetingId?: string;
   configuration?: RoomSettings;
   jwt?: string;
@@ -71,6 +72,7 @@ export const MagnifyMeeting = ({
   const getConfig = (): object => {
     return {
       ...configuration,
+      subject: props.roomDisplayName,
       toolbarButtons: getToolbarButtons(),
       prejoinConfig: {
         enabled: configuration?.waitingRoomEnabled ?? true,


### PR DESCRIPTION
## Purpose

Depending on the jitsi server settings, the name used is either invalid or not the one used to sign the JWT token.

## Proposal

- [x] Use jitsi room name given by Django backend
- [x] Set the subject room name with configOverwrite

