### PR TITLE
:lipstick: (apps:frontend) improve scroll behaviour of SimpleLayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Enable CORS Headers
 - Add Multilingual
-- Add default language management with LANGUAGE_CODE 
-- Use the backend's jitsi name to match the JWT token and set the subject to 
-the actual room name.
+- Add default language management with LANGUAGE_CODE
+- Use the backend's jitsi name to match the JWT token and set the subject to
+  the actual room name.
+- Fix the css of scrolling of the `SimpleLayout` component

--- a/src/frontend/magnify/packages/components/src/components/design-system/Layout/SimpleLayout/SimpleLayout.tsx
+++ b/src/frontend/magnify/packages/components/src/components/design-system/Layout/SimpleLayout/SimpleLayout.tsx
@@ -73,7 +73,7 @@ export const SimpleLayout = ({ urlLogo, ...props }: PropsWithChildren<Props>) =>
         color={'3d3d3d'}
         gap={'20px'}
         height={'100vh'}
-        overflow={'scroll'}
+        overflow={'auto'}
         pad={'4rem 2rem 2rem 2rem'}
         style={{ gap: '20px', flex: 2, position: 'relative' }}
       >


### PR DESCRIPTION
## Purpose

The `overflow: scroll` property was initially added to the `SimpleLayout` component  to handle the case when its height exceeds 100vh. This commit changes it to `auto` so that the scrollbar appears only when needed.

**Before:**
Useless scrolls:
![image](https://user-images.githubusercontent.com/45047538/229842367-b823e45c-288f-48fb-86d2-827754844127.png)

Only Y scroll useful:
![image](https://user-images.githubusercontent.com/45047538/229842574-9ca0e6f8-36a1-45f4-9be0-f0f9c4506c45.png)


**Now**
![image](https://user-images.githubusercontent.com/45047538/229842667-5898b2f3-1278-48f8-a544-28cd9564f68e.png)
![image](https://user-images.githubusercontent.com/45047538/229842711-ab3257be-6fc7-4ba0-81e0-692eae008577.png)




