### PR TITLE
🔧(demo) set CSRF_TRUSTED_ORIGINS for the demo

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -59,6 +59,18 @@ See [Django documentation][secret-key] for more information about this setting.
 - Default: None
 - Example: `13f1ef@^xqmc=pjv1(!hko7li2a#!f_vuv%cq8$sr2363yn^3!`
 
+#### 🔴 DJANGO_CSRF_TRUSTED_ORIGINS
+
+A list of trusted origins for unsafe requests (e.g. POST). Must at least contain the domain on
+which the backend is hosted for the Django admin site to work.
+
+See [Django documentation][csrf-trusted-origins] for more information about this setting.
+
+- Type: List as comma separated strings
+- Required: No
+- Default: [] (all originating domains are rejected)
+- Example: `https://subdomain.example1.com, https://*.example2.com`
+
 #### DJANGO_LANGUAGE_CODE
 
 A string to set the default language code for this installation. This should be in standard
@@ -71,17 +83,6 @@ At the moment, Magnify does not allow to override Django's `LANGUAGES` setting s
 - Required: No
 - Default: `en`
 - Example: `fr`
-
-#### DJANGO_CSRF_TRUSTED_ORIGINS
-
-A list of trusted origins for unsafe requests (e.g. POST).
-
-See [Django documentation][csrf-trusted-origins] for more information about this setting.
-
-- Type: List as comma separated strings
-- Required: No
-- Default: []
-- Example: `https://subdomain.example1.com, https://*.example2.com`
 
 #### DJANGO_CORS_ALLOWED_ORIGINS
 

--- a/env.d/demo
+++ b/env.d/demo
@@ -1,2 +1,3 @@
 DJANGO_ALLOWED_HOSTS=localhost
+DJANGO_CSRF_TRUSTED_ORIGINS=http://localhost:8070
 DRF_DEFAULT_AUTHENTICATION_CLASSES=magnify.apps.core.authentication.DelegatedJWTAuthentication

--- a/src/magnify/apps/core/migrations/0002_alter_user_email.py
+++ b/src/magnify/apps/core/migrations/0002_alter_user_email.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("core", "0001_initial"),
     ]


### PR DESCRIPTION
## Purpose

The demo stack was broken because it uses Production settings but we did not set CSRF trusted origins.

## Proposal

Set `CSRF_TRUSTED_ORIGINS` in the demo environment.
