### PR TITLE
(frontend) use 'back' link in Room settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Use the backend's jitsi name to match the JWT token and set the subject to
   the actual room name.
 - Fix the css of scrolling of the `SimpleLayout` component
+- Use a "back" link instead of a breadcrumb in the room settings page.

--- a/src/frontend/magnify/apps/magnify-site/src/views/rooms/settings/index.tsx
+++ b/src/frontend/magnify/apps/magnify-site/src/views/rooms/settings/index.tsx
@@ -8,7 +8,7 @@ import {
   useTranslations,
 } from '@openfun/magnify-components';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Box, Notification, Spinner } from 'grommet';
+import { Box, Button, Notification, Spinner } from 'grommet';
 import * as React from 'react';
 import { useEffect } from 'react';
 import { defineMessages } from 'react-intl';
@@ -80,7 +80,10 @@ export function RoomSettingsView() {
   };
 
   return (
-    <DefaultPage title={intl.formatMessage(roomSettingsMessages.roomSettingsTitle)}>
+    <DefaultPage
+      enableBreadcrumb={false}
+      title={intl.formatMessage(roomSettingsMessages.roomSettingsTitle)}
+    >
       <>
         {isLoading && <Spinner />}
         {!isLoading && error && (
@@ -92,6 +95,14 @@ export function RoomSettingsView() {
         )}
         {!isLoading && error == null && room && (
           <>
+            <Button
+              color={'brand'}
+              onClick={() => {
+                navigate(-1);
+              }}
+            >
+              {intl.formatMessage(commonMessages.back)}
+            </Button>
             <RoomConfig room={room} />
             <Box margin={'15px 0'}>
               <RoomUsersConfig


### PR DESCRIPTION
Resolves #175 

The only way to leave the room settings page was to click on the Breadcrumb. 
To improve this UX aspect we change it into a proper back link. 
We use the same link as in User settings page to be coherent accross the app.

![image](https://user-images.githubusercontent.com/45047538/232133739-700fe6a6-23d6-49b4-ac8e-4211879f310e.png)
