### PR TITLE
✨(frontend) allow public or private room

### DIFF
--- a/src/frontend/magnify/apps/magnify-site/src/mocks/handlers/rooms/roomsHandlers.ts
+++ b/src/frontend/magnify/apps/magnify-site/src/mocks/handlers/rooms/roomsHandlers.ts
@@ -5,6 +5,7 @@ export const defaultRoom: Room = {
   id: '123',
   name: 'test-room',
   slug: 'test-room',
+  is_public: false,
   jitsi: {
     room: 'test-room',
     token: '123',

--- a/src/frontend/magnify/apps/magnify-site/src/views/rooms/settings/index.test.tsx
+++ b/src/frontend/magnify/apps/magnify-site/src/views/rooms/settings/index.test.tsx
@@ -1,19 +1,19 @@
-import { buildApiUrl } from '@openfun/magnify-components';
+import { buildApiUrl, createRandomRoom } from '@openfun/magnify-components';
 import { render, screen } from '@testing-library/react';
 import { rest } from 'msw';
 import React from 'react';
 import { createMemoryRouter } from 'react-router-dom';
-import { describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { TestingContainer } from '../../../components/TestingContainer';
-import { defaultRoom } from '../../../mocks/handlers/rooms/roomsHandlers';
 import { server } from '../../../mocks/server';
 import { RoomSettingsView } from './index';
 
 describe('RoomSettingsView', () => {
-  it('renders', async () => {
+  it('renders private room', async () => {
     server.use(
-      rest.get(buildApiUrl('/rooms/123/'), (req, res, ctx) => {
-        return res(ctx.json([defaultRoom]));
+      rest.get(buildApiUrl('/rooms/:id/'), (req, res, ctx) => {
+        const room = createRandomRoom();
+        return res(ctx.json(room));
       }),
     );
     const router = createMemoryRouter(
@@ -26,7 +26,33 @@ describe('RoomSettingsView', () => {
       { initialEntries: ['/rooms/123/settings'], initialIndex: 1 },
     );
 
-    render(<TestingContainer router={router} />);
-    await screen.findByText('Room settings');
+    await render(<TestingContainer router={router} />);
+    await screen.findByText('Settings');
+    screen.getByText('Room settings');
+    screen.getByText('Members');
+  });
+
+  it('renders public room', async () => {
+    server.use(
+      rest.get(buildApiUrl('/rooms/:id/'), (req, res, ctx) => {
+        const room = createRandomRoom();
+        room.is_public = true;
+        return res(ctx.json(room));
+      }),
+    );
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/rooms/:id/settings',
+          element: <RoomSettingsView />,
+        },
+      ],
+      { initialEntries: ['/rooms/1234/settings'], initialIndex: 1 },
+    );
+
+    await render(<TestingContainer router={router} />);
+    await screen.findByText('Settings');
+    screen.getByText('Room settings');
+    expect(screen.queryByText('Members')).toBe(null);
   });
 });

--- a/src/frontend/magnify/apps/magnify-site/src/views/rooms/settings/index.tsx
+++ b/src/frontend/magnify/apps/magnify-site/src/views/rooms/settings/index.tsx
@@ -104,14 +104,16 @@ export function RoomSettingsView() {
               {intl.formatMessage(commonMessages.back)}
             </Button>
             <RoomConfig room={room} />
-            <Box margin={'15px 0'}>
-              <RoomUsersConfig
-                addUser={addUser}
-                onDeleteUser={deleteUser}
-                onUpdateUser={updateUser}
-                room={room}
-              />
-            </Box>
+            {room && !room.is_public && (
+              <Box margin={'15px 0'}>
+                <RoomUsersConfig
+                  addUser={addUser}
+                  onDeleteUser={deleteUser}
+                  onUpdateUser={updateUser}
+                  room={room}
+                />
+              </Box>
+            )}
           </>
         )}
       </>

--- a/src/frontend/magnify/packages/components/.storybook/preview.tsx
+++ b/src/frontend/magnify/packages/components/.storybook/preview.tsx
@@ -1,4 +1,4 @@
-import {MagnifyTestingProvider} from "../src";
+import {HttpService, MagnifyTestingProvider, TESTING_CONF} from "../src";
 import * as React from 'react';
 import {initialize, mswDecorator} from 'msw-storybook-addon';
 import {handlers} from "../src/mocks/handlers";
@@ -6,7 +6,7 @@ import '@fontsource/roboto'; // Defaults to weight 400.
 
 // Initialize MSW
 initialize();
-
+HttpService.init(TESTING_CONF.API_URL);
 
 export const decorators = [
   (Story) => (

--- a/src/frontend/magnify/packages/components/src/components/design-system/Formik/ValuesChange/FormikValuesChange.tsx
+++ b/src/frontend/magnify/packages/components/src/components/design-system/Formik/ValuesChange/FormikValuesChange.tsx
@@ -8,6 +8,7 @@ interface FormikValuesChangeProps {
   enableSubmit?: boolean;
   children?: React.ReactNode;
   forceToSubmit?: boolean;
+  onChange?: (values: any) => void;
 }
 
 export const FormikValuesChange: FunctionComponent<FormikValuesChangeProps> = ({
@@ -23,6 +24,10 @@ export const FormikValuesChange: FunctionComponent<FormikValuesChangeProps> = ({
   }, debounceTime);
 
   React.useEffect(() => {
+    if (formik.isValid) {
+      props.onChange?.(formik.values);
+    }
+
     onValuesChange();
   }, [formik.values]);
 

--- a/src/frontend/magnify/packages/components/src/components/rooms/MyRooms/MyRooms.stories.tsx
+++ b/src/frontend/magnify/packages/components/src/components/rooms/MyRooms/MyRooms.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryFn } from '@storybook/react';
 import React from 'react';
-import createRandomRoom from '../../../factories/rooms';
+import { createRandomRoom } from '../../../factories/rooms';
 import { MyRooms } from './MyRooms';
 
 export default {

--- a/src/frontend/magnify/packages/components/src/components/rooms/MyRooms/MyRooms.test.tsx
+++ b/src/frontend/magnify/packages/components/src/components/rooms/MyRooms/MyRooms.test.tsx
@@ -1,9 +1,9 @@
 import { screen } from '@testing-library/react';
 import React from 'react';
 import { beforeAll, expect, vi } from 'vitest';
-import createRandomRoom from '../../../factories/rooms';
+import { createRandomRoom } from '../../../factories';
 import { KeycloakService } from '../../../services';
-import { renderWrappedInTestingProvider } from '../../../utils/test-utils';
+import { renderWrappedInTestingProvider } from '../../../utils';
 
 import { MyRooms } from './MyRooms';
 

--- a/src/frontend/magnify/packages/components/src/components/rooms/RegisterRoom/RegisterRoom.test.tsx
+++ b/src/frontend/magnify/packages/components/src/components/rooms/RegisterRoom/RegisterRoom.test.tsx
@@ -1,8 +1,8 @@
 import { act, screen, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import createRandomRoom from '../../../factories/rooms';
-import { renderWrappedInTestingProvider } from '../../../utils/test-utils';
+import { createRandomRoom } from '../../../factories';
+import { renderWrappedInTestingProvider } from '../../../utils';
 import { RegisterRoom } from './RegisterRoom';
 
 describe('RegisterRoom', () => {

--- a/src/frontend/magnify/packages/components/src/components/rooms/RoomConfig/RoomConfig.stories.tsx
+++ b/src/frontend/magnify/packages/components/src/components/rooms/RoomConfig/RoomConfig.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryFn } from '@storybook/react';
 import React from 'react';
-import createRandomRoom from '../../../factories/rooms';
+import { createRandomRoom } from '../../../factories/rooms';
 import { RoomConfig } from './RoomConfig';
 
 export default {

--- a/src/frontend/magnify/packages/components/src/components/rooms/RoomConfig/RoomConfig.test.tsx
+++ b/src/frontend/magnify/packages/components/src/components/rooms/RoomConfig/RoomConfig.test.tsx
@@ -1,11 +1,12 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
+import { createRandomRoom } from '../../../factories/rooms';
 import { MagnifyTestingProvider } from '../../app';
 import { RoomConfig } from './RoomConfig';
 
 describe('RoomConfig', () => {
   it('should fetch data from the controller', async () => {
-    render(<RoomConfig room={undefined} />, { wrapper: MagnifyTestingProvider });
+    render(<RoomConfig room={createRandomRoom()} />, { wrapper: MagnifyTestingProvider });
 
     // Wait for loading to finish
     const checkboxes = screen.getAllByRole('checkbox');

--- a/src/frontend/magnify/packages/components/src/components/rooms/RoomConfig/Users/RoomUsersConfig.stories.tsx
+++ b/src/frontend/magnify/packages/components/src/components/rooms/RoomConfig/Users/RoomUsersConfig.stories.tsx
@@ -1,6 +1,6 @@
-import { Meta, StoryFn } from '@storybook/react';
+import { Meta } from '@storybook/react';
 import React from 'react';
-import createRandomRoom from '../../../../factories/rooms';
+import { createRandomRoom } from '../../../../factories';
 import { RoomUsersConfig } from './RoomUsersConfig';
 
 export default {

--- a/src/frontend/magnify/packages/components/src/components/rooms/RoomConfig/Users/RoomUsersConfig.test.tsx
+++ b/src/frontend/magnify/packages/components/src/components/rooms/RoomConfig/Users/RoomUsersConfig.test.tsx
@@ -5,7 +5,7 @@ import { ResponsiveContext } from 'grommet';
 import React from 'react';
 import { describe, it, Mock, vi } from 'vitest';
 
-import createRandomRoom from '../../../../factories/rooms';
+import { createRandomRoom } from '../../../../factories';
 import { Room } from '../../../../types';
 import { ArrayHelper } from '../../../../utils/helpers/array';
 import { MagnifyTestingProvider } from '../../../app';

--- a/src/frontend/magnify/packages/components/src/components/rooms/RoomRow/RoomRow.stories.tsx
+++ b/src/frontend/magnify/packages/components/src/components/rooms/RoomRow/RoomRow.stories.tsx
@@ -1,8 +1,8 @@
-import { Meta, StoryFn } from '@storybook/react';
+import { Meta } from '@storybook/react';
 import React from 'react';
 import { withRouter } from 'storybook-addon-react-router-v6';
-import createRandomRoom from '../../../factories/rooms';
-import { RoomRow, RoomRowProps } from './RoomRow';
+import { createRandomRoom } from '../../../factories/rooms';
+import { RoomRow } from './RoomRow';
 
 export default {
   title: 'Rooms/RoomRow',

--- a/src/frontend/magnify/packages/components/src/components/rooms/RoomRow/RoomRow.test.tsx
+++ b/src/frontend/magnify/packages/components/src/components/rooms/RoomRow/RoomRow.test.tsx
@@ -2,8 +2,8 @@ import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
-import createRandomRoom from '../../../factories/rooms';
-import { Room } from '../../../types/entities/room';
+import { createRandomRoom } from '../../../factories';
+import { Room } from '../../../types';
 import { MagnifyTestingProvider } from '../../app';
 import { RoomRow } from './RoomRow';
 

--- a/src/frontend/magnify/packages/components/src/factories/rooms/index.ts
+++ b/src/frontend/magnify/packages/components/src/factories/rooms/index.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { Room, RoomAccessRole, RoomUserAccesses } from '../../types';
 
-export default function createRandomRoom(isAdmin: boolean = true): Room {
+export function createRandomRoom(isAdmin: boolean = true): Room {
   const id = faker.datatype.uuid();
   const name = faker.lorem.slug();
   const result: Room = {
@@ -9,6 +9,7 @@ export default function createRandomRoom(isAdmin: boolean = true): Room {
     name: name,
     slug: faker.lorem.slug(),
     is_administrable: isAdmin,
+    is_public: false,
     jitsi: {
       token: '123',
       room: `${name}-${id}`,

--- a/src/frontend/magnify/packages/components/src/mocks/allHandlers/rooms/roomsHandlers.ts
+++ b/src/frontend/magnify/packages/components/src/mocks/allHandlers/rooms/roomsHandlers.ts
@@ -1,14 +1,14 @@
 import { faker } from '@faker-js/faker';
 import { rest } from 'msw';
-import { buildApiUrl } from '../../../services/http/http.service';
-import { Room, RoomAccessRole } from '../../../types/entities/room';
-import { MagnifyLocales } from '../../../utils';
-import { RoomsApiRoutes } from '../../../utils/routes/api';
+import { buildApiUrl, RoutesBuilderService } from '../../../services';
+import { Room, RoomAccessRole } from '../../../types';
+import { MagnifyLocales, RoomsApiRoutes } from '../../../utils';
 
 export const defaultRoom: Room = {
   id: '123',
   name: 'test-room',
   slug: 'test-room',
+  is_public: false,
   jitsi: {
     room: 'test-room',
     token: '123',
@@ -39,4 +39,10 @@ export const roomsHandlers = [
   rest.post(buildApiUrl(RoomsApiRoutes.GET), (req, res, ctx) => {
     return res(ctx.json(defaultRoom));
   }),
+  rest.patch(
+    RoutesBuilderService.buildWithBaseUrl(RoomsApiRoutes.UPDATE, { id: ':id' }),
+    (req, res, ctx) => {
+      return res(ctx.json(defaultRoom));
+    },
+  ),
 ];

--- a/src/frontend/magnify/packages/components/src/services/routes/RoutesBuilder.service.ts
+++ b/src/frontend/magnify/packages/components/src/services/routes/RoutesBuilder.service.ts
@@ -1,3 +1,5 @@
+import { HttpService } from '../http';
+
 export interface UrlBuilderParams {
   [key: string]: string | number;
 }
@@ -11,5 +13,10 @@ export class RoutesBuilderService {
     });
 
     return output;
+  }
+
+  public static buildWithBaseUrl(route: string, params: UrlBuilderParams = {}) {
+    const newRoute = `${HttpService.baseUrl}${route}`;
+    return RoutesBuilderService.build(newRoute, params);
   }
 }

--- a/src/frontend/magnify/packages/components/src/types/entities/room/index.ts
+++ b/src/frontend/magnify/packages/components/src/types/entities/room/index.ts
@@ -18,6 +18,7 @@ export interface Room {
   name: string;
   slug: string;
   is_administrable: boolean;
+  is_public: boolean;
   jitsi: {
     room: string;
     token: string;


### PR DESCRIPTION

## Purpose

Currently, when we create a room, this room is automatically private. We must be able to have the choice to make this room public or private. 

## Proposal

We add a switch to the room settings page.