### PR TITLE
✨(jitsi) allow adding a prefix to the Jitsi room names

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -213,6 +213,16 @@ authenticate requests.
     ```
 - Example: `{"email": "email", "name": "name", "username": "preferred_username"}`
 
+#### MAGNIFY_JITSI_ROOM_PREFIX
+
+A prefix that will be added in front of the room UUID to compose the Jitsi room name used
+for the conference.
+
+- Type: string
+- Required: No
+- Default: ""
+- Example: `123`
+
 #### MAGNIFY_ALLOW_UNREGISTERED_ROOMS
 
 Whether users can join a room that is not reserved in Magnify. When activated, Magnify will

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -137,6 +137,9 @@ class Base(MagnifyCoreConfigurationMixin, Configuration):
         ),
     }
 
+    JITSI_ROOM_PREFIX = values.Value(
+        "", environ_name="MAGNIFY_JITSI_ROOM_PREFIX", environ_prefix=None
+    )
     ALLOW_UNREGISTERED_ROOMS = values.BooleanValue(
         True, environ_name="MAGNIFY_ALLOW_UNREGISTERED_ROOMS", environ_prefix=None
     )

--- a/src/magnify/apps/core/models.py
+++ b/src/magnify/apps/core/models.py
@@ -402,7 +402,7 @@ class Room(Resource):
     @property
     def jitsi_name(self):
         """The name used for the room in Jitsi."""
-        return str(self.id).replace("-", "")
+        return f"{settings.JITSI_ROOM_PREFIX}{self.id!s}".replace("-", "")
 
 
 class Meeting(BaseModel):
@@ -511,7 +511,7 @@ class Meeting(BaseModel):
     @property
     def jitsi_name(self):
         """The name used as Jitsi room for this meeting."""
-        return str(self.id).replace("-", "")
+        return f"{settings.JITSI_ROOM_PREFIX}{self.id!s}".replace("-", "")
 
     def is_guest(self, user):
         """Return True if the user is a guest, either directly or via a group."""

--- a/tests/apps/core/test_core_models_meetings.py
+++ b/tests/apps/core/test_core_models_meetings.py
@@ -6,6 +6,7 @@ from zoneinfo import ZoneInfo
 
 from django.core.exceptions import ValidationError
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from magnify.apps.core.factories import MeetingFactory
 from magnify.apps.core.models import Meeting
@@ -54,3 +55,9 @@ class MeetingsModelsTestCase(TestCase):
         """The Jitsi name should be the meeting ID stripped of all dashes."""
         meeting = MeetingFactory(id="2a76d5ee-8310-4a28-8e7f-c34dbdc4dd8a")
         self.assertEqual(meeting.jitsi_name, "2a76d5ee83104a288e7fc34dbdc4dd8a")
+
+    @override_settings(JITSI_ROOM_PREFIX="1-2-3")
+    def test_models_meetings_name_prefix(self):
+        """It should be possible to set a prefix on the Jitsi room name."""
+        room = MeetingFactory(id="f629e68e-e256-44fe-8ba6-a7e0849de00b")
+        self.assertEqual(room.jitsi_name, "123f629e68ee25644fe8ba6a7e0849de00b")

--- a/tests/apps/core/test_core_models_rooms.py
+++ b/tests/apps/core/test_core_models_rooms.py
@@ -4,6 +4,7 @@ Unit tests for the Room model
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ValidationError
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from magnify.apps.core.factories import (
     GroupFactory,
@@ -48,6 +49,12 @@ class RoomsModelsTestCase(TestCase):
                 "Ensure this value has at most 100 characters (it has 101).",
             ],
         )
+
+    @override_settings(JITSI_ROOM_PREFIX="1-2-3")
+    def test_models_rooms_name_prefix(self):
+        """It should be possible to set a prefix on the Jitsi room name."""
+        room = RoomFactory(id="f629e68e-e256-44fe-8ba6-a7e0849de00b")
+        self.assertEqual(room.jitsi_name, "123f629e68ee25644fe8ba6a7e0849de00b")
 
     def test_models_rooms_slug_unique(self):
         """Room slugs should be unique."""


### PR DESCRIPTION
## Purpose

We may want to namespace room names in the same Jitsi instance or we may want to include a text in the room names.

## Proposal

- Add a prefix to the Jitsi room name for both the Meeting and Room models
- Allow setting the Jitsi room prefix by setting the `MAGNIFY_JITSI_ROOM_PREFIX` environment variable
- Update the environment variables documentation to add the new setting
