### PR TITLE
Hide public rooms from list endpoint

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -223,6 +223,19 @@ for the conference.
 - Default: ""
 - Example: `123`
 
+#### MAGNIFY_DEFAULT_ROOM_IS_PUBLIC
+
+Whether rooms are created as public by default. Rooms that are not marked as public, will not
+deliver any Jitsi JWT token to users who are not authenticated or to users who have not been
+assigned any role in the room.
+
+- Type: Boolean as string
+  * True: 'yes', 'y', 'true', '1'
+  * False: 'no', 'n', 'false', '0', '' (empty string)
+- Required: No
+- Default: True
+- Example: `false`
+
 #### MAGNIFY_ALLOW_UNREGISTERED_ROOMS
 
 Whether users can join a room that is not reserved in Magnify. When activated, Magnify will

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -140,6 +140,9 @@ class Base(MagnifyCoreConfigurationMixin, Configuration):
     JITSI_ROOM_PREFIX = values.Value(
         "", environ_name="MAGNIFY_JITSI_ROOM_PREFIX", environ_prefix=None
     )
+    DEFAULT_ROOM_IS_PUBLIC = values.BooleanValue(
+        True, environ_name="MAGNIFY_DEFAULT_ROOM_IS_PUBLIC", environ_prefix=None
+    )
     ALLOW_UNREGISTERED_ROOMS = values.BooleanValue(
         True, environ_name="MAGNIFY_ALLOW_UNREGISTERED_ROOMS", environ_prefix=None
     )

--- a/src/frontend/packages/core/src/components/rooms/RoomConfig/RoomConfig.tsx
+++ b/src/frontend/packages/core/src/components/rooms/RoomConfig/RoomConfig.tsx
@@ -161,7 +161,7 @@ export const RoomConfig = ({ room }: RoomConfigProps) => {
     roomPassword: room?.configuration?.roomPassword ?? '',
     waitingRoomEnabled: room?.configuration?.waitingRoomEnabled ?? true,
     enableLobbyChat: room?.configuration?.enableLobbyChat ?? true,
-    startAudioMuted: room?.configuration?.startAudioMuted ?? false,
+    startWithAudioMuted: room?.configuration?.startWithAudioMuted ?? false,
     startWithVideoMuted: room?.configuration?.startWithVideoMuted ?? true,
     screenSharingEnabled: room?.configuration?.screenSharingEnabled ?? true,
     is_public: room.is_public,
@@ -235,7 +235,7 @@ export const RoomConfig = ({ room }: RoomConfigProps) => {
                   <Box gap="xxsmall" height="100%">
                     <FormikSwitch
                       label={intl.formatMessage(roomConfigMessages.everyoneStartsMuted)}
-                      name="startAudioMuted"
+                      name="startWithAudioMuted"
                     />
                     <FormikSwitch
                       label={intl.formatMessage(roomConfigMessages.everyoneStartsWithoutCamera)}

--- a/src/frontend/packages/core/src/types/entities/room/index.ts
+++ b/src/frontend/packages/core/src/types/entities/room/index.ts
@@ -8,7 +8,7 @@ export interface RoomSettings {
   roomPassword?: string;
   waitingRoomEnabled?: boolean;
   enableLobbyChat?: boolean;
-  startAudioMuted?: boolean;
+  startWithAudioMuted?: boolean;
   startWithVideoMuted?: boolean;
   screenSharingEnabled?: boolean;
 }
@@ -33,7 +33,7 @@ export const defaultConfiguration: RoomSettings = {
   roomPassword: '',
   waitingRoomEnabled: true,
   enableLobbyChat: true,
-  startAudioMuted: false,
+  startWithAudioMuted: false,
   startWithVideoMuted: true,
   screenSharingEnabled: true,
 };

--- a/src/magnify/apps/core/api/rooms.py
+++ b/src/magnify/apps/core/api/rooms.py
@@ -70,17 +70,19 @@ class RoomViewSet(
     def list(self, request, *args, **kwargs):
         """Limit listed rooms to the ones related to the authenticated user."""
         user = self.request.user
-        queryset = self.filter_queryset(self.get_queryset())
 
         if user.is_authenticated:
-            queryset = queryset.filter(
-                Q(is_public=True)
-                | Q(users=user)
-                | Q(groups__members=user)
-                | Q(groups__administrators=user)
-            ).distinct()
+            queryset = (
+                self.filter_queryset(self.get_queryset())
+                .filter(
+                    Q(users=user)
+                    | Q(groups__members=user)
+                    | Q(groups__administrators=user)
+                )
+                .distinct()
+            )
         else:
-            queryset = queryset.filter(is_public=True)
+            queryset = self.get_queryset().none()
 
         page = self.paginate_queryset(queryset)
         if page is not None:

--- a/src/magnify/apps/core/models.py
+++ b/src/magnify/apps/core/models.py
@@ -201,7 +201,7 @@ class Group(BaseModel):
 class Resource(BaseModel):
     """Model to define access control"""
 
-    is_public = models.BooleanField(default=False)
+    is_public = models.BooleanField(default=settings.DEFAULT_ROOM_IS_PUBLIC)
     users = models.ManyToManyField(
         User,
         through="ResourceAccess",

--- a/tests/apps/core/test_core_models_rooms.py
+++ b/tests/apps/core/test_core_models_rooms.py
@@ -111,9 +111,9 @@ class RoomsModelsTestCase(TestCase):
         self.assertEqual(list(room.labels.all()), [label])
 
     def test_models_rooms_is_public_default(self):
-        """A room should not be public by default."""
+        """A room should be public by default."""
         room = Room.objects.create(name="room")
-        self.assertFalse(room.is_public)
+        self.assertTrue(room.is_public)
 
     # Access rights methods
 


### PR DESCRIPTION
## Purpose

Currently, public rooms are listed on every users' dashboard. Although we want every user be able to join a public room, we don't want them to see it in their personal list of rooms.

We want rooms to be private by default (even better make it configurable via settings)

Finally, the Jitsi parameter to start with audio muted does not work.

## Proposal

- [x] Filter out public rooms on rooms' list API endpoint.
- [x] Add a new setting `DEFAULT_IS_PUBLIC` to determine if a room is public or private by default
- [x] Fix typo on the parameter to start with audio muted
