### PR TITLE
🚸(frontend) move room public switch to the security section

### DIFF
--- a/src/frontend/packages/core/src/components/rooms/RoomConfig/RoomConfig.tsx
+++ b/src/frontend/packages/core/src/components/rooms/RoomConfig/RoomConfig.tsx
@@ -216,10 +216,6 @@ export const RoomConfig = ({ room }: RoomConfigProps) => {
                 <MagnifyCard title={intl.formatMessage(roomConfigMessages.settingsTitle)}>
                   <Box gap="xxsmall">
                     <FormikSwitch
-                      label={intl.formatMessage(roomConfigMessages.isPublicRoom)}
-                      name="is_public"
-                    />
-                    <FormikSwitch
                       label={intl.formatMessage(roomConfigMessages.enableChat)}
                       name="enableLobbyChat"
                     />
@@ -247,6 +243,10 @@ export const RoomConfig = ({ room }: RoomConfigProps) => {
               <Box gap={'10px'} gridArea={'security'}>
                 <MagnifyCard title={intl.formatMessage(roomConfigMessages.securityTitle)}>
                   <Box gap="xxsmall">
+                    <FormikSwitch
+                      label={intl.formatMessage(roomConfigMessages.isPublicRoom)}
+                      name="is_public"
+                    />
                     <FormikSwitch
                       label={intl.formatMessage(roomConfigMessages.enableWaitingRoom)}
                       name="waitingRoomEnabled"


### PR DESCRIPTION
## Purpose

It appears that it makes more sens to list this switch in the security section.

## Proposal

Move widget to the security section.