### PR TITLE
✨(frontend) Allow room administrator to show / hide input password

### DIFF
--- a/src/frontend/packages/core/src/components/rooms/RoomConfig/RoomConfig.tsx
+++ b/src/frontend/packages/core/src/components/rooms/RoomConfig/RoomConfig.tsx
@@ -261,6 +261,7 @@ export const RoomConfig = ({ room }: RoomConfigProps) => {
                           fullWidth={true}
                           label={intl.formatMessage(roomConfigMessages.askForPasswordInputLabel)}
                           name="roomPassword"
+                          type={'password'}
                         />
                       )}
                     </Box>


### PR DESCRIPTION
## Purpose

In room settings view, user is able to protect access to its room through a password. Currently the input field to set the password is a text input so its value is always visible that is weird.


## Proposal
 
- Add type='password' 

Close #216 
