### PR TITLE
✨(frontend) Make the "Members" section always visible and functional

### DIFF
--- a/src/frontend/packages/core/src/views/rooms/settings/index.test.tsx
+++ b/src/frontend/packages/core/src/views/rooms/settings/index.test.tsx
@@ -33,7 +33,7 @@ describe('RoomSettingsView', () => {
     screen.getByText('Members');
   });
 
-  it('renders privfate room', async () => {
+  it('renders public room', async () => {
     server.use(
       rest.get(buildApiUrl('/rooms/:id/'), (req, res, ctx) => {
         const room = createRandomRoom();
@@ -54,6 +54,6 @@ describe('RoomSettingsView', () => {
     await render(<TestingContainer router={router} />);
     await screen.findByText('Settings');
     screen.getByText('Room settings');
-    expect(screen.queryByText('Members')).toBe(null);
+    expect(screen.queryByText('Members')).not.toBe(null);
   });
 });

--- a/src/frontend/packages/core/src/views/rooms/settings/index.tsx
+++ b/src/frontend/packages/core/src/views/rooms/settings/index.tsx
@@ -91,20 +91,18 @@ export function RoomSettingsView() {
           />
         )}
         {!isLoading && error == null && room && (
-          <>
+          <Box gap="15px">
             <BackButton />
             <RoomConfig room={room} />
-            {room && !room.is_public && (
-              <Box margin={'15px 0'}>
-                <RoomUsersConfig
-                  addUser={addUser}
-                  onDeleteUser={deleteUser}
-                  onUpdateUser={updateUser}
-                  room={room}
-                />
-              </Box>
-            )}
-          </>
+            <Box margin={'15px 0'}>
+              <RoomUsersConfig
+                addUser={addUser}
+                onDeleteUser={deleteUser}
+                onUpdateUser={updateUser}
+                room={room}
+              />
+            </Box>
+          </Box>
         )}
       </>
     </DefaultPage>


### PR DESCRIPTION
## Purpose

When a room is marked as public, its list of members is hidden

## Proposal

Make the "Members" section always visible and functional.
Secure behavior with a test.

Close #219