### PR TITLE
🐛(frontend/core) use `config.LANGUAGE_CODE` to set default locale

### DIFF
--- a/src/frontend/packages/core/src/components/app/MagnifyProvider/index.tsx
+++ b/src/frontend/packages/core/src/components/app/MagnifyProvider/index.tsx
@@ -53,7 +53,7 @@ export const MagnifyProvider = ({
   }, [config]);
 
   return (
-    <TranslationProvider locale={locale}>
+    <TranslationProvider locale={locale || config.LANGUAGE_CODE}>
       <FormErrors />
       <Grommet full theme={themeConfig}>
         <CunninghamProvider>

--- a/src/frontend/packages/core/src/components/app/MagnifyTestingProvider/index.tsx
+++ b/src/frontend/packages/core/src/components/app/MagnifyTestingProvider/index.tsx
@@ -52,7 +52,11 @@ export const MagnifyTestingProvider = (props: MagnifyTestingProviderProps) => {
   }, []);
 
   return (
-    <TranslationProvider defaultLocale="en" initTranslation={false} locale={locale}>
+    <TranslationProvider
+      defaultLocale="en"
+      initTranslation={false}
+      locale={locale || TESTING_CONF.LANGUAGE_CODE}
+    >
       <FormErrors />
       <RoutingContextProvider routes={getRouter()}>
         <CunninghamProvider>

--- a/src/frontend/sandbox/public/config.json
+++ b/src/frontend/sandbox/public/config.json
@@ -4,6 +4,7 @@
   "KEYCLOAK_CLIENT_ID": "magnify-front",
   "KEYCLOAK_EXPIRATION_SECONDS": 1800,
   "KEYCLOAK_REALM": "magnify",
+  "KEYCLOAK_URL": "http://localhost:8080",
+  "LANGUAGE_CODE": "en"
   "MAGNIFY_SHOW_REGISTER_LINK": true,
-  "KEYCLOAK_URL": "http://localhost:8080"
 }


### PR DESCRIPTION
## Purpose

The default `LANGUAGE_CODE` to use in the frontend application is bound to the config information retrieved through the backend api. Currently, this information was not use to set the default locale of the TranslationProvider so English was always used until user logged in and the magnify-locale is set into the local storage.

Fix #235