### PR TITLE
✅(backend) replace deprecated TimeZoneField.get_default_zoneinfo_tzs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -68,6 +68,7 @@ dev =
     pytest-django==4.5.2
     responses==0.23.1
     time-machine==2.10.0
+    pytz==2023.3.post1
 ci =
     twine==4.0.2
 sandbox =

--- a/src/magnify/apps/core/factories.py
+++ b/src/magnify/apps/core/factories.py
@@ -10,8 +10,8 @@ from django.contrib.auth.hashers import make_password
 from django.utils.text import slugify
 
 import factory
+import pytz
 from factory import fuzzy
-from timezone_field import TimeZoneField
 
 from . import models as core_models
 
@@ -28,7 +28,7 @@ class UserFactory(factory.django.DjangoModelFactory):
     email = factory.Faker("email")
     jwt_sub = factory.Faker("uuid4")
     language = fuzzy.FuzzyChoice([lang[0] for lang in settings.LANGUAGES])
-    timezone = fuzzy.FuzzyChoice(TimeZoneField.get_default_zoneinfo_tzs())
+    timezone = fuzzy.FuzzyChoice([ZoneInfo(tz) for tz in pytz.all_timezones])
     name = factory.Faker("name")
     password = make_password("password")
 
@@ -158,7 +158,7 @@ class MeetingFactory(factory.django.DjangoModelFactory):
     name = factory.Faker("catch_phrase")
     owner = factory.SubFactory(UserFactory)
     start = factory.Faker("future_datetime", tzinfo=ZoneInfo("UTC"))
-    timezone = fuzzy.FuzzyChoice(TimeZoneField.get_default_zoneinfo_tzs())
+    timezone = fuzzy.FuzzyChoice([ZoneInfo(tz) for tz in pytz.all_timezones])
 
     @factory.lazy_attribute
     def end(self):


### PR DESCRIPTION
## Purpose

Since django-timezone-field version 6, the static method `get_default_zoneinfo_tzs` has been removed from the class TimeZoneField. As we were using this method within our factories, our test suites were broken. So we decide to install pytz and retrieve all existing timezones from this library to replace the deprecated method.


## Proposal

- [x] Install pytz as deps dependency
- [x] Replace deprecated `get_default_zoneinfo_tzs` by a comprehension list based on pytz
